### PR TITLE
✨ Attach the video player as a slide-out drawer on the HUD

### DIFF
--- a/apps/macos/Sources/Pomo/AppDelegate.swift
+++ b/apps/macos/Sources/Pomo/AppDelegate.swift
@@ -12,7 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let chime = CompletionChime()
     private let audio = AudioController()
     private let favorites = FavoritesStore()
-    private lazy var hud = HUDController(model: model, settings: settings)
+    private lazy var hud = HUDController(model: model, settings: settings, audio: audio)
     private lazy var menuBar = MenuBarController(model: model, settings: settings, audio: audio, favorites: favorites)
     private var settingsWindow: NSWindow?
 

--- a/apps/macos/Sources/Pomo/AppDelegate.swift
+++ b/apps/macos/Sources/Pomo/AppDelegate.swift
@@ -162,6 +162,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .videoShow:   audio.setVideoVisible(true)
         case .videoHide:   audio.setVideoVisible(false)
         case .videoToggle: audio.toggleVideo()
+        case .videoBrowser: audio.openInBrowser()
         case .favoriteAdd(let url, let title):
             favorites.add(url: url, title: title)
         case .favoritePlay(let index):

--- a/apps/macos/Sources/Pomo/Audio/AudioController.swift
+++ b/apps/macos/Sources/Pomo/Audio/AudioController.swift
@@ -49,6 +49,10 @@ final class AudioController {
     func setVideoVisible(_ visible: Bool) { web.setWindowVisible(visible); syncVideo(); notify() }
     func toggleVideo() { web.toggleWindow(); syncVideo(); notify() }
 
+    /// Pop the currently-playing video out to the default browser (where
+    /// playlists, autoplay, queue and the user's extensions all work).
+    func openInBrowser() { web.openInBrowser() }
+
     /// Wire the drawer to the HUD panel when it appears / detach when it hides.
     func attachDrawer(to anchor: NSWindow?) { web.hudDidAppear(anchor: anchor); syncVideo() }
     func detachDrawer() { web.hudWillDisappear() }

--- a/apps/macos/Sources/Pomo/Audio/AudioController.swift
+++ b/apps/macos/Sources/Pomo/Audio/AudioController.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 
@@ -18,6 +19,14 @@ final class AudioController {
     private(set) var engineName = "none"   // "web" | "none" (kept in state.json)
     private(set) var currentURL = ""
 
+    /// Whether the video drawer is open. Stored (not computed) so the on-face
+    /// buttons observe it and re-render when it toggles.
+    private(set) var videoOpen = false
+
+    /// Edge the drawer is docked to — the HUD reads this to square the matching
+    /// corners so the two read as one block.
+    private(set) var videoEdge: DrawerEdge = .right
+
     var videoVisible: Bool { web.isWindowVisible }
 
     init() {
@@ -37,8 +46,17 @@ final class AudioController {
     func importCookies(browser: String?, profile: String?) { web.importCookies(fromBrowser: browser, profile: profile) }
     func clearLogin() { web.clearLogin() }
     func setAccount(_ index: Int) { web.setAccount(index) }
-    func setVideoVisible(_ visible: Bool) { web.setWindowVisible(visible) }
-    func toggleVideo() { web.toggleWindow() }
+    func setVideoVisible(_ visible: Bool) { web.setWindowVisible(visible); syncVideo(); notify() }
+    func toggleVideo() { web.toggleWindow(); syncVideo(); notify() }
+
+    /// Wire the drawer to the HUD panel when it appears / detach when it hides.
+    func attachDrawer(to anchor: NSWindow?) { web.hudDidAppear(anchor: anchor); syncVideo() }
+    func detachDrawer() { web.hudWillDisappear() }
+
+    private func syncVideo() {
+        videoOpen = web.isWindowVisible
+        videoEdge = web.drawerEdge
+    }
 
     private func notify() {
         isPlaying = web.isPlaying

--- a/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
@@ -180,6 +180,29 @@ final class WebAudioPlayer: NSObject {
 
     @objc private func didTapExpand() { setExpanded(!drawerExpanded) }
 
+    @objc private func didTapOpenInBrowser() { openInBrowser() }
+
+    /// Pop the *currently playing* page (playlist/index intact) out to the
+    /// default browser, where playlists, autoplay and the user's extensions work.
+    func openInBrowser() {
+        guard let url = webView?.url ?? (currentURL.isEmpty ? nil : URL(string: currentURL)) else { return }
+        log("open in browser \(url.absoluteString)")
+        NSWorkspace.shared.open(url)
+    }
+
+    private static func overlayButton(symbol: String, tip: String, target: Any?, action: Selector) -> NSButton {
+        let b = NSButton(image: NSImage(systemSymbolName: symbol, accessibilityDescription: tip) ?? NSImage(),
+                         target: target, action: action)
+        b.isBordered = false
+        b.imagePosition = .imageOnly
+        b.contentTintColor = .white
+        b.wantsLayer = true
+        b.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.42).cgColor
+        b.layer?.cornerRadius = 11
+        b.toolTip = tip
+        return b
+    }
+
     // MARK: - Drawer geometry + slide animation
 
     /// First edge (right → left → below → above) with room for the collapsed
@@ -493,21 +516,20 @@ final class WebAudioPlayer: NSObject {
             wv.autoresizingMask = [.width, .height]
             container.addSubview(wv)
 
-            let expand = NSButton(
-                image: NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: "Expand") ?? NSImage(),
-                target: self, action: #selector(didTapExpand)
-            )
-            expand.isBordered = false
-            expand.imagePosition = .imageOnly
-            expand.contentTintColor = .white
-            expand.wantsLayer = true
-            expand.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.42).cgColor
-            expand.layer?.cornerRadius = 11
-            let bsize: CGFloat = 22, margin: CGFloat = 8
+            // Corner overlay buttons, pinned top-right: open-in-browser, then expand.
+            let bsize: CGFloat = 22, margin: CGFloat = 8, gap: CGFloat = 6
+            let expand = Self.overlayButton(symbol: "arrow.up.left.and.arrow.down.right",
+                                            tip: "Expand to full page", target: self, action: #selector(didTapExpand))
             expand.frame = NSRect(x: frame.width - bsize - margin, y: frame.height - bsize - margin, width: bsize, height: bsize)
-            expand.autoresizingMask = [.minXMargin, .minYMargin]   // pin to top-right
+            expand.autoresizingMask = [.minXMargin, .minYMargin]
             container.addSubview(expand)
             self.expandButton = expand
+
+            let browser = Self.overlayButton(symbol: "safari",
+                                             tip: "Open in browser", target: self, action: #selector(didTapOpenInBrowser))
+            browser.frame = NSRect(x: frame.width - bsize * 2 - margin - gap, y: frame.height - bsize - margin, width: bsize, height: bsize)
+            browser.autoresizingMask = [.minXMargin, .minYMargin]
+            container.addSubview(browser)
 
             let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
             window.isReleasedWhenClosed = false

--- a/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
@@ -9,6 +9,9 @@ import AppKit
 ///
 /// Cookies/login persist in the default (disk-backed) `WKWebsiteDataStore`, which
 /// the sign-in window shares, so a one-time login sticks across launches.
+/// Which edge of the HUD the drawer docks against (and slides out from).
+enum DrawerEdge { case right, left, below, above }
+
 @MainActor
 final class WebAudioPlayer: NSObject {
     private static let desktopUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
@@ -23,8 +26,25 @@ final class WebAudioPlayer: NSObject {
     private(set) var currentURL: String = ""
     private var volume: Int = 60
 
-    /// Whether the mini-player window is shown. Toggleable at runtime.
-    private(set) var windowVisible = true
+    /// User intent: whether the video drawer is open. Toggleable at runtime; kept
+    /// across HUD hide/show so the drawer returns alongside the panel.
+    private(set) var drawerOpen = false
+
+    /// Edge the drawer last docked to — drives the HUD's seam-squaring.
+    private(set) var drawerEdge: DrawerEdge = .right
+
+    /// Expanded = full page (playlist/related) at a larger size; collapsed =
+    /// chrome-stripped "screen" matched to the HUD.
+    private(set) var drawerExpanded = false
+
+    /// The HUD panel the drawer attaches to and slides out from. Weak — the
+    /// panel owns its own lifecycle; we just track and dock against it.
+    private weak var anchorWindow: NSWindow?
+
+    /// Rounded container hosting the web view + the expand button overlay.
+    private var drawerContainer: NSView?
+    private var expandButton: NSButton?
+    private static let drawerRadius: CGFloat = 12
 
     /// Fired when playback state changes (from JS player events).
     var onStateChange: (() -> Void)?
@@ -71,7 +91,7 @@ final class WebAudioPlayer: NSObject {
         webView?.load(URLRequest(url: URL(string: "about:blank")!))
         currentURL = ""
         isPlaying = false
-        hostWindow?.orderOut(nil)
+        setWindowVisible(false)
     }
 
     func setVolume(_ value: Double) {
@@ -97,17 +117,217 @@ final class WebAudioPlayer: NSObject {
         ]))
     }
 
-    // MARK: - Window (show video) toggle
+    // MARK: - Attached video drawer
 
-    var isWindowVisible: Bool { hostWindow?.isVisible ?? false }
+    /// Reflects user intent (not raw window visibility) so the on-face toggle
+    /// stays correct even mid-animation.
+    var isWindowVisible: Bool { drawerOpen }
 
+    /// Show/hide the drawer with a slide animation. Opening lazily builds the
+    /// web view if it doesn't exist yet.
     func setWindowVisible(_ visible: Bool) {
-        windowVisible = visible
-        guard let hostWindow else { return }
-        if visible { hostWindow.orderFrontRegardless() } else { hostWindow.orderOut(nil) }
+        drawerOpen = visible
+        if visible {
+            ensureWebView()
+            openDrawer()
+        } else {
+            closeDrawer()
+        }
     }
 
-    func toggleWindow() { setWindowVisible(!isWindowVisible) }
+    func toggleWindow() { setWindowVisible(!drawerOpen) }
+
+    /// The HUD appeared: anchor to it and, if the drawer was open, slide it back
+    /// out alongside the (possibly repositioned) panel.
+    func hudDidAppear(anchor: NSWindow?) {
+        anchorWindow = anchor
+        if drawerOpen { openDrawer() }
+    }
+
+    /// The HUD is hiding: tuck the drawer away with it, keeping the open intent
+    /// so it returns on the next summon.
+    func hudWillDisappear() {
+        guard let host = hostWindow else { return }
+        if let anchor = anchorWindow, host.parent === anchor { anchor.removeChildWindow(host) }
+        host.orderOut(nil)
+        host.alphaValue = 1
+    }
+
+    /// Expand the drawer to the full page (playlist/related, chrome shown) or
+    /// collapse it back to the chrome-stripped "screen" that matches the HUD.
+    func setExpanded(_ on: Bool) {
+        guard drawerOpen, let host = hostWindow, let anchor = anchorWindow else { return }
+        drawerExpanded = on
+        applyBare(!on)                      // bare (chrome hidden) only when collapsed
+        applyDrawerCorners()
+        updateExpandButton()
+        let a = anchor.frame
+        let open = drawerFrame(size: size(for: drawerEdge, in: a), edge: drawerEdge, anchor: a)
+        if host.parent === anchor { anchor.removeChildWindow(host) }
+        host.order(.below, relativeTo: anchor.windowNumber)
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.26
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            host.animator().setFrame(open, display: true)
+        }, completionHandler: { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self, let host = self.hostWindow, let anchor = self.anchorWindow,
+                      self.drawerOpen, host.parent !== anchor else { return }
+                anchor.addChildWindow(host, ordered: .below)
+            }
+        })
+    }
+
+    @objc private func didTapExpand() { setExpanded(!drawerExpanded) }
+
+    // MARK: - Drawer geometry + slide animation
+
+    /// First edge (right → left → below → above) with room for the collapsed
+    /// drawer beside the HUD.
+    private func chooseEdge(_ a: NSRect, _ screen: NSRect) -> DrawerEdge {
+        let sideW = collapsedSize(.right).width, vertH = collapsedSize(.below).height
+        if a.maxX - seam + sideW <= screen.maxX { return .right }
+        if a.minX + seam - sideW >= screen.minX { return .left }
+        if a.minY + seam - vertH >= screen.minY { return .below }
+        if a.maxY - seam + vertH <= screen.maxY { return .above }
+        return .right
+    }
+
+    private static let seamOverlap: CGFloat = 2     // hairline tuck so no desktop shows through
+    private var seam: CGFloat { Self.seamOverlap }
+
+    /// Collapsed matches the HUD across the shared edge; height/width filled in
+    /// from the anchor at call sites that have it.
+    private func collapsedSize(_ edge: DrawerEdge, hud: NSRect = .zero) -> NSSize {
+        switch edge {
+        case .right, .left: return NSSize(width: 360, height: hud.height == 0 ? 244 : hud.height)
+        case .below, .above: return NSSize(width: hud.width == 0 ? 352 : hud.width, height: 202)
+        }
+    }
+
+    private func expandedSize(_ edge: DrawerEdge, hud: NSRect) -> NSSize {
+        switch edge {
+        case .right, .left: return NSSize(width: 480, height: max(hud.height, 340))
+        case .below, .above: return NSSize(width: max(hud.width, 460), height: 360)
+        }
+    }
+
+    private func size(for edge: DrawerEdge, in hud: NSRect) -> NSSize {
+        drawerExpanded ? expandedSize(edge, hud: hud) : collapsedSize(edge, hud: hud)
+    }
+
+    /// Place a drawer of `size` flush against `edge` of the HUD, centred on the
+    /// cross axis and tucked `seam` px behind it.
+    private func drawerFrame(size s: NSSize, edge: DrawerEdge, anchor a: NSRect) -> NSRect {
+        switch edge {
+        case .right: return NSRect(x: a.maxX - seam,            y: a.midY - s.height / 2, width: s.width, height: s.height)
+        case .left:  return NSRect(x: a.minX + seam - s.width,  y: a.midY - s.height / 2, width: s.width, height: s.height)
+        case .below: return NSRect(x: a.midX - s.width / 2,     y: a.minY + seam - s.height, width: s.width, height: s.height)
+        case .above: return NSRect(x: a.midX - s.width / 2,     y: a.maxY - seam, width: s.width, height: s.height)
+        }
+    }
+
+    /// The collapsed open frame shifted fully behind the HUD along the slide axis.
+    private func tuckedFrame(_ open: NSRect, edge: DrawerEdge) -> NSRect {
+        switch edge {
+        case .right: return open.offsetBy(dx: -open.width, dy: 0)
+        case .left:  return open.offsetBy(dx:  open.width, dy: 0)
+        case .below: return open.offsetBy(dx: 0, dy:  open.height)
+        case .above: return open.offsetBy(dx: 0, dy: -open.height)
+        }
+    }
+
+    /// Slide the drawer out from behind the HUD, then adopt it as a child window
+    /// so it tracks the panel when dragged.
+    private func openDrawer() {
+        guard let host = hostWindow else { return }
+        guard let anchor = anchorWindow else { host.orderFrontRegardless(); return }
+        let a = anchor.frame
+        let screen = (anchor.screen ?? NSScreen.main)?.visibleFrame ?? a
+        drawerEdge = chooseEdge(a, screen)
+        applyDrawerCorners()
+        applyBare(!drawerExpanded)
+        applyVideoQuality()              // bump if it was playing audio-only at low res
+
+        let collapsedOpen = drawerFrame(size: collapsedSize(drawerEdge, hud: a), edge: drawerEdge, anchor: a)
+        let open = drawerFrame(size: size(for: drawerEdge, in: a), edge: drawerEdge, anchor: a)
+        host.setFrame(tuckedFrame(collapsedOpen, edge: drawerEdge), display: false)
+        host.alphaValue = 0
+        host.order(.below, relativeTo: anchor.windowNumber)        // emerge from behind
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.32
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            host.animator().setFrame(open, display: true)
+            host.animator().alphaValue = 1
+        }, completionHandler: { [weak self] in
+            MainActor.assumeIsolated {       // NSAnimationContext fires on the main thread
+                guard let self, let host = self.hostWindow, let anchor = self.anchorWindow,
+                      self.drawerOpen, host.parent !== anchor else { return }
+                anchor.addChildWindow(host, ordered: .below)
+            }
+        })
+    }
+
+    /// Slide the drawer back behind the HUD and order it out (resetting to the
+    /// collapsed screen so the next open is compact).
+    private func closeDrawer() {
+        guard let host = hostWindow, host.isVisible else {
+            hostWindow?.orderOut(nil); return
+        }
+        let target: NSRect
+        if let anchor = anchorWindow {
+            let a = anchor.frame
+            let collapsedOpen = drawerFrame(size: collapsedSize(drawerEdge, hud: a), edge: drawerEdge, anchor: a)
+            target = tuckedFrame(collapsedOpen, edge: drawerEdge)
+            if host.parent === anchor { anchor.removeChildWindow(host) }
+            host.order(.below, relativeTo: anchor.windowNumber)
+        } else {
+            target = host.frame
+        }
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.24
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            host.animator().setFrame(target, display: true)
+            host.animator().alphaValue = 0
+        }, completionHandler: { [weak self] in
+            MainActor.assumeIsolated {       // NSAnimationContext fires on the main thread
+                guard let self, let host = self.hostWindow, !self.drawerOpen else { return }
+                host.orderOut(nil)
+                host.alphaValue = 1
+                self.drawerExpanded = false
+                self.updateExpandButton()
+            }
+        })
+    }
+
+    /// Round only the *outer* corners when collapsed (so the inner edge butts the
+    /// HUD square — one block); round all four when expanded (free-floating panel).
+    private func applyDrawerCorners() {
+        guard let layer = drawerContainer?.layer else { return }
+        layer.cornerRadius = Self.drawerRadius
+        if drawerExpanded {
+            layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner,
+                                   .layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+            return
+        }
+        switch drawerEdge {                                       // keep the 2 corners away from the HUD
+        case .right: layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
+        case .left:  layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
+        case .below: layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        case .above: layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        }
+    }
+
+    /// Toggle the injected "bare" class that strips YouTube to just the player.
+    private func applyBare(_ bare: Bool) {
+        eval("(function(){var h=document.documentElement;if(h){h.classList[\(bare ? "add" : "remove")]('pomo-bare');}})();")
+    }
+
+    private func updateExpandButton() {
+        let symbol = drawerExpanded ? "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right"
+        expandButton?.image = NSImage(systemSymbolName: symbol, accessibilityDescription: drawerExpanded ? "Collapse" : "Expand")
+        expandButton?.toolTip = drawerExpanded ? "Collapse to screen" : "Expand to full page"
+    }
 
     // MARK: - Sign in (persistent profile)
 
@@ -193,6 +413,53 @@ final class WebAudioPlayer: NSObject {
 
     private func eval(_ js: String) { webView?.evaluateJavaScript(js, completionHandler: nil) }
 
+    /// Injected as a "content script": a user stylesheet that, while the
+    /// `pomo-bare` class is on `<html>`, strips YouTube down to just the player +
+    /// its transport controls. Toggling the class (see `applyBare`) flips between
+    /// the bare screen and the full page with no reload.
+    private static let bareScript = """
+    (function(){
+      var CSS = `
+      html.pomo-bare, html.pomo-bare body { overflow:hidden!important; background:#000!important; }
+      html.pomo-bare ytd-masthead, html.pomo-bare #masthead-container, html.pomo-bare #masthead,
+      html.pomo-bare tp-yt-app-header, html.pomo-bare #secondary, html.pomo-bare #secondary-inner,
+      html.pomo-bare #below, html.pomo-bare ytd-watch-metadata, html.pomo-bare #comments,
+      html.pomo-bare #chat, html.pomo-bare ytmusic-nav-bar, html.pomo-bare #merch-shelf,
+      html.pomo-bare ytd-watch-next-secondary-results-renderer { display:none!important; }
+      html.pomo-bare #movie_player, html.pomo-bare .html5-video-player {
+        position:fixed!important; inset:0!important; width:100vw!important; height:100vh!important;
+        max-width:none!important; max-height:none!important; margin:0!important;
+        z-index:2147483640!important; background:#000!important;
+      }
+      html.pomo-bare .html5-video-container { width:100%!important; height:100%!important; }
+      html.pomo-bare video.html5-main-video {
+        width:100%!important; height:100%!important; top:0!important; left:0!important; object-fit:cover!important;
+      }
+      html.pomo-bare .ytp-chrome-top, html.pomo-bare .ytp-gradient-top, html.pomo-bare .ytp-pause-overlay,
+      html.pomo-bare .ytp-ce-element, html.pomo-bare .ytp-show-cards-title { display:none!important; }
+      html.pomo-bare ::-webkit-scrollbar { display:none!important; }
+      `;
+      function inject(){
+        var h = document.head || document.documentElement;
+        if (h && !document.getElementById('pomo-skin')) {
+          var s = document.createElement('style'); s.id = 'pomo-skin'; s.textContent = CSS; h.appendChild(s);
+        }
+        if (document.documentElement) document.documentElement.classList.add('pomo-bare');
+      }
+      inject();
+      document.addEventListener('DOMContentLoaded', inject);
+    })();
+    """
+
+    /// Crisp while the drawer is visible; lowest (audio-only) while hidden to
+    /// save bandwidth.
+    private var videoQuality: String { drawerOpen ? "hd720" : "tiny" }
+
+    private func applyVideoQuality() {
+        let q = videoQuality
+        eval("(function(){var mp=document.getElementById('movie_player');if(mp){try{mp.setPlaybackQualityRange&&mp.setPlaybackQualityRange('\(q)','\(q)');}catch(e){}try{mp.setPlaybackQuality&&mp.setPlaybackQuality('\(q)');}catch(e){}}})();")
+    }
+
     private func ensureWebView() {
         if webView == nil {
             let config = WKWebViewConfiguration()
@@ -202,25 +469,60 @@ final class WebAudioPlayer: NSObject {
             let messageProxy = MessageProxy(self)
             self.messageProxy = messageProxy
             config.userContentController.add(messageProxy, name: "pomo")
+            // Our "extension": strip the page to just the player while bare.
+            config.userContentController.addUserScript(
+                WKUserScript(source: Self.bareScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            )
 
-            let frame = NSRect(x: 0, y: 0, width: 380, height: 214)
+            let frame = NSRect(x: 0, y: 0, width: 360, height: 244)
             let wv = WKWebView(frame: frame, configuration: config)
             wv.customUserAgent = Self.desktopUA
             let navProxy = NavProxy(self)
             self.navProxy = navProxy
             wv.navigationDelegate = navProxy
 
-            let window = NSWindow(contentRect: frame, styleMask: [.titled, .closable], backing: .buffered, defer: false)
-            window.title = "Pomo · Audio"
+            // Rounded container clips the web view and hosts the expand button, so
+            // the drawer reads as a screen tucked against the HUD. Per-corner
+            // rounding (see applyDrawerCorners) squares the edge facing the HUD.
+            let container = NSView(frame: frame)
+            container.wantsLayer = true
+            container.layer?.cornerRadius = Self.drawerRadius
+            container.layer?.masksToBounds = true
+            container.layer?.backgroundColor = NSColor.black.cgColor
+            wv.frame = container.bounds
+            wv.autoresizingMask = [.width, .height]
+            container.addSubview(wv)
+
+            let expand = NSButton(
+                image: NSImage(systemSymbolName: "arrow.up.left.and.arrow.down.right", accessibilityDescription: "Expand") ?? NSImage(),
+                target: self, action: #selector(didTapExpand)
+            )
+            expand.isBordered = false
+            expand.imagePosition = .imageOnly
+            expand.contentTintColor = .white
+            expand.wantsLayer = true
+            expand.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.42).cgColor
+            expand.layer?.cornerRadius = 11
+            let bsize: CGFloat = 22, margin: CGFloat = 8
+            expand.frame = NSRect(x: frame.width - bsize - margin, y: frame.height - bsize - margin, width: bsize, height: bsize)
+            expand.autoresizingMask = [.minXMargin, .minYMargin]   // pin to top-right
+            container.addSubview(expand)
+            self.expandButton = expand
+
+            let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
             window.isReleasedWhenClosed = false
+            window.isOpaque = false
+            window.backgroundColor = .clear
+            window.hasShadow = true
             window.level = .floating
             window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-            window.contentView = wv
+            window.contentView = container
             positionBottomRight(window)
             hostWindow = window
             webView = wv
+            drawerContainer = container
+            updateExpandButton()
         }
-        if windowVisible { hostWindow?.orderFrontRegardless() }
     }
 
     private func positionBottomRight(_ window: NSWindow) {
@@ -240,12 +542,12 @@ final class WebAudioPlayer: NSObject {
             var v = document.querySelector('video,audio');
             if (v) {
               try { v.volume = \(volume)/100.0; } catch(e){}
-              // Lowest video quality — we only want the audio. (Audio is served
-              // independently, so it stays full quality.)
+              // Crisp while the drawer is on screen; lowest (audio-only) when
+              // hidden. Audio is served independently, so it stays full quality.
               var mp = document.getElementById('movie_player');
               if (mp) {
-                try { mp.setPlaybackQualityRange && mp.setPlaybackQualityRange('tiny','tiny'); } catch(e){}
-                try { mp.setPlaybackQuality && mp.setPlaybackQuality('tiny'); } catch(e){}
+                try { mp.setPlaybackQualityRange && mp.setPlaybackQualityRange('\(videoQuality)','\(videoQuality)'); } catch(e){}
+                try { mp.setPlaybackQuality && mp.setPlaybackQuality('\(videoQuality)'); } catch(e){}
               }
               v.play().then(function(){ post('playing'); }).catch(function(e){ post('playfail:'+e); });
               if (!v.__pomo) {
@@ -262,6 +564,7 @@ final class WebAudioPlayer: NSObject {
         })();
         """
         eval(js)
+        applyBare(!drawerExpanded)        // a fresh navigation re-asserts the bare default
     }
 
     fileprivate func handlePlayerEvent(_ body: Any) {

--- a/apps/macos/Sources/Pomo/Control/AgentControl.swift
+++ b/apps/macos/Sources/Pomo/Control/AgentControl.swift
@@ -22,6 +22,7 @@ enum PomoCommand {
     case videoShow
     case videoHide
     case videoToggle
+    case videoBrowser           // open the current video in the default browser
     case favoriteAdd(url: String, title: String?)
     case favoritePlay(Int)      // 1-based
     case favoriteRemove(Int)    // 1-based
@@ -71,6 +72,7 @@ enum PomoCommand {
             switch arg {
             case "show":   self = .videoShow
             case "hide":   self = .videoHide
+            case "browser", "open": self = .videoBrowser
             case "toggle", nil: self = .videoToggle
             default: return nil
             }

--- a/apps/macos/Sources/Pomo/HUD/HUDController.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDController.swift
@@ -8,6 +8,7 @@ import SwiftUI
 final class HUDController {
     private let model: TimerModel
     private let settings: PomoSettings
+    private let audio: AudioController
 
     /// Opens the settings window (⌘,). Wired by AppDelegate.
     var onOpenSettings: (() -> Void)?
@@ -18,9 +19,10 @@ final class HUDController {
     private var hasPositioned = false
     private(set) var isShown = false
 
-    init(model: TimerModel, settings: PomoSettings) {
+    init(model: TimerModel, settings: PomoSettings, audio: AudioController) {
         self.model = model
         self.settings = settings
+        self.audio = audio
     }
 
     // MARK: - Panel lifecycle
@@ -29,7 +31,7 @@ final class HUDController {
         if let panel { return panel }
         let panel = HUDPanel(contentSize: contentSize)
         let hosting = NSHostingView(
-            rootView: HUDRootView(model: model, settings: settings, size: contentSize)
+            rootView: HUDRootView(model: model, settings: settings, audio: audio, size: contentSize)
         )
         hosting.frame = NSRect(origin: .zero, size: contentSize)
         hosting.autoresizingMask = [.width, .height]
@@ -61,12 +63,15 @@ final class HUDController {
             ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
             panel.animator().alphaValue = CGFloat(settings.panelOpacity)
         }
+        // Dock the video drawer to the panel (slides back out if it was open).
+        audio.attachDrawer(to: panel)
     }
 
     func hide() {
         guard let panel, isShown else { return }
         isShown = false
         removeKeyMonitor()
+        audio.detachDrawer()
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.14
             ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)

--- a/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
@@ -8,12 +8,55 @@ import HudsonShell
 struct HUDRootView: View {
     let model: TimerModel
     let settings: PomoSettings
+    let audio: AudioController
     let size: CGSize
+
+    /// The two on-face audio buttons show once a station is configured or
+    /// something is playing. Reading `audio`/`settings` here keeps them live.
+    private var audioFaceControls: AudioFaceControls {
+        AudioFaceControls(
+            enabled: !settings.audioURL.isEmpty || audio.isPlaying || !audio.currentURL.isEmpty,
+            isPlaying: audio.isPlaying,
+            drawerOpen: audio.videoOpen,
+            togglePlay: {
+                if audio.isPlaying { audio.pause() }
+                else { audio.resume(stored: settings.audioURL) }
+            },
+            toggleDrawer: {
+                // Opening with nothing loaded yet? Kick off the saved station so
+                // the drawer has something to show.
+                if !audio.videoOpen, !audio.isPlaying, audio.currentURL.isEmpty,
+                   !settings.audioURL.isEmpty {
+                    audio.play(urlString: settings.audioURL)
+                }
+                audio.toggleVideo()
+            }
+        )
+    }
 
     // The Blueprint face reads as a drafting sheet, so it wants hard, near-square
     // corners; every other face keeps the soft frosted-HUD radius.
-    private var cornerRadius: CGFloat {
-        settings.watchface == .blueprint ? 0 : 18
+    private var baseRadius: CGFloat {
+        settings.watchface == .blueprint ? 0 : 12
+    }
+
+    // When the video drawer is docked, square the two corners on its side so the
+    // HUD and drawer read as one continuous block rather than two cards kissing.
+    private var cornerRadii: RectangleCornerRadii {
+        let r = baseRadius
+        guard audio.videoOpen, settings.watchface != .blueprint else {
+            return RectangleCornerRadii(topLeading: r, bottomLeading: r, bottomTrailing: r, topTrailing: r)
+        }
+        switch audio.videoEdge {
+        case .right: return RectangleCornerRadii(topLeading: r, bottomLeading: r, bottomTrailing: 0, topTrailing: 0)
+        case .left:  return RectangleCornerRadii(topLeading: 0, bottomLeading: 0, bottomTrailing: r, topTrailing: r)
+        case .below: return RectangleCornerRadii(topLeading: r, bottomLeading: 0, bottomTrailing: 0, topTrailing: r)
+        case .above: return RectangleCornerRadii(topLeading: 0, bottomLeading: r, bottomTrailing: r, topTrailing: 0)
+        }
+    }
+
+    private var panelShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(cornerRadii: cornerRadii, style: .continuous)
     }
 
     var body: some View {
@@ -36,13 +79,13 @@ struct HUDRootView: View {
             WatchfaceView(face: settings.watchface, model: model)
         }
         .frame(width: size.width, height: size.height)
-        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .clipShape(panelShape)
         .overlay(
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            panelShape
                 .stroke(Color.white.opacity(0.10), lineWidth: 1)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            panelShape
                 .stroke(Color.black.opacity(0.35), lineWidth: 1)
                 .blendMode(.plusDarker)
                 .padding(0.5)
@@ -50,5 +93,6 @@ struct HUDRootView: View {
         // Panel-level opacity is applied to the window's alphaValue by
         // HUDController (so it composes with the summon/dismiss fade).
         .environment(\.hudTheme, .default)
+        .environment(\.audioControls, audioFaceControls)
     }
 }

--- a/apps/macos/Sources/Pomo/Watchfaces/AudioControls.swift
+++ b/apps/macos/Sources/Pomo/Watchfaces/AudioControls.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// State + actions for the on-face audio controls — a play/pause for the
+/// background music and a show/hide for the attached video drawer. Injected by
+/// `HUDRootView` through the environment so the shared `FaceControls` row can
+/// render the two extra buttons without every watchface having to thread audio
+/// state through its own signature.
+///
+/// The buttons only appear when `enabled` (a station is configured or playing).
+struct AudioFaceControls {
+    var enabled: Bool = false
+    var isPlaying: Bool = false
+    var drawerOpen: Bool = false
+    var togglePlay: () -> Void = {}
+    var toggleDrawer: () -> Void = {}
+}
+
+private struct AudioFaceControlsKey: EnvironmentKey {
+    static let defaultValue = AudioFaceControls()
+}
+
+extension EnvironmentValues {
+    var audioControls: AudioFaceControls {
+        get { self[AudioFaceControlsKey.self] }
+        set { self[AudioFaceControlsKey.self] = newValue }
+    }
+}

--- a/apps/macos/Sources/Pomo/Watchfaces/WatchfaceView.swift
+++ b/apps/macos/Sources/Pomo/Watchfaces/WatchfaceView.swift
@@ -27,26 +27,54 @@ struct FaceControls: View {
     var tint: Color
     var subtle: Bool = false
 
+    @Environment(\.audioControls) private var audio
+
     var body: some View {
-        HStack(spacing: HudSpacing.xl) {
-            Button(action: { model.reset() }) {
-                Image(systemName: "arrow.counterclockwise")
-            }
-            .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
-            .help("Reset (R)")
+        HStack(spacing: HudSpacing.lg) {
+            // Timer transport — the original reset / play-pause / skip cluster.
+            HStack(spacing: HudSpacing.xl) {
+                Button(action: { model.reset() }) {
+                    Image(systemName: "arrow.counterclockwise")
+                }
+                .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
+                .help("Reset (R)")
 
-            Button(action: { model.toggle() }) {
-                Image(systemName: model.isRunning ? "pause.fill" : "play.fill")
-            }
-            .buttonStyle(FaceControlStyle(tint: tint, prominent: true, subtle: subtle))
-            .help(model.isRunning ? "Pause (Space)" : "Start (Space)")
+                Button(action: { model.toggle() }) {
+                    Image(systemName: model.isRunning ? "pause.fill" : "play.fill")
+                }
+                .buttonStyle(FaceControlStyle(tint: tint, prominent: true, subtle: subtle))
+                .help(model.isRunning ? "Pause (Space)" : "Start (Space)")
 
-            Button(action: { model.skip() }) {
-                Image(systemName: "forward.end.fill")
+                Button(action: { model.skip() }) {
+                    Image(systemName: "forward.end.fill")
+                }
+                .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
+                .help("Skip to next session (N)")
             }
-            .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
-            .help("Skip to next session (N)")
+
+            // Audio cluster — appears only once a station is set/playing.
+            if audio.enabled {
+                Rectangle()
+                    .fill(tint.opacity(subtle ? 0.18 : 0.3))
+                    .frame(width: 1, height: 16)
+
+                HStack(spacing: HudSpacing.lg) {
+                    Button(action: audio.togglePlay) {
+                        Image(systemName: audio.isPlaying ? "pause.fill" : "music.note")
+                    }
+                    .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
+                    .help(audio.isPlaying ? "Pause music" : "Play music")
+
+                    Button(action: audio.toggleDrawer) {
+                        Image(systemName: audio.drawerOpen ? "rectangle.fill" : "play.rectangle")
+                    }
+                    .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
+                    .help(audio.drawerOpen ? "Hide video" : "Show video")
+                }
+                .transition(.opacity.combined(with: .move(edge: .trailing)))
+            }
         }
+        .animation(.easeOut(duration: 0.2), value: audio.enabled)
     }
 }
 


### PR DESCRIPTION
Makes the web/YouTube player feel physically attached to the HUD — it slides out from behind the panel and docks as one block, instead of floating in a corner.

## What's in it
- **Attached drawer.** The player window becomes a child window of the HUD panel: it auto-picks the edge with room (right → left → below → above), matches the HUD's height (sideways) or width (up/down), slides out from behind, and tracks the HUD when you drag it. Hides with the HUD, returns on summon.
- **On-face controls.** Two buttons in the shared transport row — play/pause music + show/hide video — shown only when a station is set.
- **One block.** Radius 18→12, inner corners squared on the docked edge (`UnevenRoundedRectangle` on the HUD, `maskedCorners` on the drawer), 2px tuck so there's no seam.
- **Bare mode.** A `WKUserScript` strips YouTube to just the player + its transport controls; toggled via a CSS class (no reload). Adaptive quality: hd720 while visible, 144p when hidden (audio only).
- **Open in browser.** A corner button pops the *currently playing* page (playlist/index intact) into the default browser. Plus `pomo://video/show|hide|toggle|browser` handles.

## Notes / open threads
- The on-drawer **expand** button (full page) is in but lightweight — may drop it in favour of just open-in-browser.
- A slim **up-next/queue strip** would pair well once playlists/autoplay are enabled — possible follow-up.
- Unrelated `.github/workflows/macos-swift.yml` change in the working tree was intentionally left out of this branch.