### PR TITLE
✨ Adaptive light/dark: redesigned Settings + light-mode popover

### DIFF
--- a/apps/macos/Sources/Pomo/AppDelegate.swift
+++ b/apps/macos/Sources/Pomo/AppDelegate.swift
@@ -265,7 +265,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         let window = NSWindow(contentViewController: NSHostingController(rootView: view))
         window.title = "Pomo Settings"
-        window.styleMask = [.titled, .closable]
+        // Resizable, with a transparent full-height titlebar so the sidebar runs
+        // to the top (System-Settings style). The view follows the system
+        // light/dark appearance via `AppPalette`, so we don't force one here.
+        window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.setContentSize(NSSize(width: 720, height: 560))
+        window.contentMinSize = NSSize(width: 640, height: 480)
+        // A settings window shouldn't persist/restore its transient UI state
+        // (e.g. the selected tab); always open fresh on General.
+        window.isRestorable = false
         window.isReleasedWhenClosed = false
         window.delegate = self
         window.center()

--- a/apps/macos/Sources/Pomo/Core/AppPalette.swift
+++ b/apps/macos/Sources/Pomo/Core/AppPalette.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// Pomo's adaptive surface palette — the colours for app **windows** (Settings,
+/// Stats) that sit against the user's desktop and therefore follow the system
+/// light/dark appearance.
+///
+/// Hudson's `HudPalette` / `HudSurface` are deliberately fixed-dark (they dress
+/// the always-dark HUD), so we can't lean on them here. Rather than depend on a
+/// framework "light" palette of unknown completeness, Pomo owns both ends of the
+/// ramp explicitly — the same approach the Lattices app takes with its `Palette`.
+/// Dark values mirror the HUD's near-black glass; light values are a clean,
+/// System-Settings-flavoured on-light treatment.
+struct AppPalette {
+    /// Detail / content background.
+    let bg: Color
+    /// Sidebar background (slightly offset from `bg` for separation).
+    let sidebar: Color
+    /// Raised card fill.
+    let surface: Color
+    /// Hover / selected row fill.
+    let surfaceHover: Color
+    /// Recessed control fill (text fields, icon buttons).
+    let inset: Color
+    /// Primary text.
+    let ink: Color
+    /// Secondary text.
+    let muted: Color
+    /// Tertiary text / disabled.
+    let dim: Color
+    /// Card / control borders.
+    let border: Color
+    /// Hairline dividers (lighter than `border`).
+    let hairline: Color
+    /// Brand accent (Pomo yellow) — used sparingly, e.g. the hourglass.
+    let accent: Color
+    /// Functional action accent (green) — primary buttons, toggles, sliders.
+    let action: Color
+
+    static let dark = AppPalette(
+        bg:           Color(hex: 0x161618),
+        sidebar:      Color(hex: 0x111113),
+        surface:      Color(hex: 0x202023),
+        surfaceHover: Color(hex: 0x2A2A2E),
+        inset:        Color(hex: 0x0D0D0F),
+        ink:          Color.white.opacity(0.92),
+        muted:        Color.white.opacity(0.60),
+        dim:          Color.white.opacity(0.40),
+        border:       Color.white.opacity(0.08),
+        hairline:     Color.white.opacity(0.06),
+        accent:       PomoBrand.accent,
+        action:       Color(hex: 0x3DD66B)
+    )
+
+    static let light = AppPalette(
+        bg:           Color(hex: 0xF5F5F7),
+        sidebar:      Color(hex: 0xECECEE),
+        surface:      Color(hex: 0xFFFFFF),
+        surfaceHover: Color.black.opacity(0.045),
+        inset:        Color.black.opacity(0.05),
+        ink:          Color(hex: 0x1B1B20),
+        muted:        Color.black.opacity(0.56),
+        dim:          Color.black.opacity(0.40),
+        border:       Color.black.opacity(0.10),
+        hairline:     Color.black.opacity(0.07),
+        accent:       PomoBrand.accent,
+        action:       Color(hex: 0x27B257)
+    )
+
+    static func resolve(_ scheme: ColorScheme) -> AppPalette {
+        scheme == .light ? .light : .dark
+    }
+}

--- a/apps/macos/Sources/Pomo/MenuBar/MenuBarController.swift
+++ b/apps/macos/Sources/Pomo/MenuBar/MenuBarController.swift
@@ -178,7 +178,9 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         let popover = NSPopover()
         popover.contentViewController = host
         popover.behavior = .transient
-        popover.appearance = NSAppearance(named: .darkAqua)
+        // No forced appearance — the popover sits against the user's desktop, so
+        // it follows the system light/dark setting (MenuPopoverView themes itself
+        // off `colorScheme`). The HUD stays dark; the menu popover adapts.
         popover.delegate = self
         self.popover = popover
         return popover

--- a/apps/macos/Sources/Pomo/MenuBar/MenuPopoverView.swift
+++ b/apps/macos/Sources/Pomo/MenuBar/MenuPopoverView.swift
@@ -6,6 +6,12 @@ import HudsonShell
 /// A compact, HUD-flavoured panel: live countdown + progress, transport
 /// controls, session and watchface pickers, and a "Show HUD" affordance.
 ///
+/// Unlike the HUD (which is always a dark frosted panel), the menu-bar popover
+/// **follows the system appearance** — it sits against the user's desktop, so a
+/// forced-dark panel reads as out of place on a light Mac. We drive Hudson's
+/// theme + a scheme-aware palette off `colorScheme` so the popover is a clean
+/// light panel in light mode and the familiar dark HUD surface in dark mode.
+///
 /// Right-clicking the menu-bar item opens a small native menu instead
 /// (Settings / Quit) — see `MenuBarController`. The HUD itself stays
 /// hotkey-driven.
@@ -21,8 +27,25 @@ struct MenuPopoverView: View {
     var onStopAudio: () -> Void
     var onPlayFavorite: (Favorite) -> Void
 
+    @Environment(\.colorScheme) private var scheme
+
     private var session: SessionType { model.sessionType }
     private var tint: HudTint { session.tint }
+
+    // MARK: - Adaptive theme
+
+    /// Hudson's static `HudPalette` / `HudSurface` colours are fixed-dark and do
+    /// not follow `\.hudTheme`, so we read the theme palette directly and pick
+    /// light vs dark off the system appearance. (`lightDraft` is Hudson's light
+    /// palette; `default` is the dark HUD palette.)
+    private var theme: HudTheme { scheme == .light ? .lightDraft : .default }
+    private var pal: HudThemePalette { scheme == .light ? .lightDraft : .default }
+
+    /// Scheme-aware inset / tinted surfaces for the chips + icon buttons, since
+    /// `HudSurface` is dark-only. In light mode we derive subtle on-light fills.
+    private var insetFill: Color { scheme == .light ? Color.black.opacity(0.05) : HudSurface.inset }
+    private func tintFill(_ c: Color) -> Color { scheme == .light ? c.opacity(0.16) : HudSurface.tintFill(c) }
+    private func tintBorder(_ c: Color) -> Color { scheme == .light ? c.opacity(0.55) : HudSurface.tintBorder(c) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: HudSpacing.xl) {
@@ -38,16 +61,22 @@ struct MenuPopoverView: View {
         .padding(HudSpacing.xxl)
         .frame(width: 288)
         .background(frostedBackground)
-        .environment(\.hudTheme, .default)
+        .environment(\.hudTheme, theme)
     }
 
-    // MARK: - Background (mirrors the HUD's frosted card)
+    // MARK: - Background (frosted card that follows the system appearance)
 
     private var frostedBackground: some View {
         ZStack {
-            HudVisualEffectView(material: .hudWindow, blendingMode: .behindWindow, state: .active)
+            HudVisualEffectView(
+                material: scheme == .light ? .popover : .hudWindow,
+                blendingMode: .behindWindow,
+                state: .active
+            )
             LinearGradient(
-                colors: [Color.black.opacity(0.46), Color.black.opacity(0.34)],
+                colors: scheme == .light
+                    ? [Color.white.opacity(0.45), Color.white.opacity(0.24)]
+                    : [Color.black.opacity(0.46), Color.black.opacity(0.34)],
                 startPoint: .top,
                 endPoint: .bottom
             )
@@ -62,7 +91,7 @@ struct MenuPopoverView: View {
             Text("POMO")
                 .font(HudFont.mono(HudTextSize.xxs, weight: .bold))
                 .tracking(2)
-                .foregroundStyle(HudPalette.dim)
+                .foregroundStyle(pal.dim)
             Spacer()
             HudBadge(session.label, tint: tint.color, dot: true)
         }
@@ -75,10 +104,10 @@ struct MenuPopoverView: View {
             Text(model.clock)
                 .font(HudFont.mono(HudTextSize.hero, weight: .medium))
                 .monospacedDigit()
-                .foregroundStyle(HudPalette.ink)
+                .foregroundStyle(pal.ink)
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
-                    Capsule().fill(HudPalette.ink.opacity(0.10))
+                    Capsule().fill(pal.ink.opacity(0.10))
                     Capsule()
                         .fill(tint.color)
                         .frame(width: max(0, geo.size.width * model.progress))
@@ -99,15 +128,15 @@ struct MenuPopoverView: View {
         )
         .textFieldStyle(.plain)
         .font(HudFont.mono(HudTextSize.sm))
-        .foregroundStyle(HudPalette.ink)
+        .foregroundStyle(pal.ink)
         .padding(.horizontal, HudSpacing.lg)
         .frame(height: 30)
         .background(
             RoundedRectangle(cornerRadius: HudRadius.standard)
-                .fill(HudPalette.bg)
+                .fill(pal.bg)
                 .overlay(
                     RoundedRectangle(cornerRadius: HudRadius.standard)
-                        .stroke(HudPalette.border, lineWidth: 1)
+                        .stroke(pal.border, lineWidth: 1)
                 )
         )
     }
@@ -168,7 +197,7 @@ struct MenuPopoverView: View {
                 chip(
                     label: face.displayName,
                     selected: face == settings.watchface,
-                    tint: HudPalette.accent,
+                    tint: pal.accent,
                     enabled: true
                 ) {
                     settings.watchface = face
@@ -195,10 +224,10 @@ struct MenuPopoverView: View {
                         .font(HudFont.mono(HudTextSize.xs, weight: .medium))
                         .lineLimit(1)
                         .truncationMode(.tail)
-                        .foregroundStyle(audio.currentURL.isEmpty ? HudPalette.dim : HudPalette.ink)
+                        .foregroundStyle(audio.currentURL.isEmpty ? pal.dim : pal.ink)
                     Text(nowPlayingSubtitle)
                         .font(HudFont.mono(HudTextSize.micro))
-                        .foregroundStyle(audio.isPlaying ? tint.color : HudPalette.dim)
+                        .foregroundStyle(audio.isPlaying ? tint.color : pal.dim)
                 }
                 Spacer(minLength: 0)
             }
@@ -210,7 +239,7 @@ struct MenuPopoverView: View {
                         chip(
                             label: favorite.title,
                             selected: favorite.url == audio.currentURL,
-                            tint: HudPalette.accent,
+                            tint: pal.accent,
                             enabled: true
                         ) { onPlayFavorite(favorite) }
                     }
@@ -220,13 +249,13 @@ struct MenuPopoverView: View {
             HStack(spacing: HudSpacing.sm) {
                 Image(systemName: "speaker.fill")
                     .font(HudFont.ui(HudTextSize.micro))
-                    .foregroundStyle(HudPalette.dim)
+                    .foregroundStyle(pal.dim)
                 Slider(value: settings.binding(\.audioVolume), in: 0...1)
                     .controlSize(.mini)
                     .tint(tint.color)
                 Image(systemName: "speaker.wave.3.fill")
                     .font(HudFont.ui(HudTextSize.micro))
-                    .foregroundStyle(HudPalette.dim)
+                    .foregroundStyle(pal.dim)
             }
         }
     }
@@ -254,12 +283,12 @@ struct MenuPopoverView: View {
 
     private var footer: some View {
         VStack(spacing: HudSpacing.lg) {
-            Divider().overlay(HudPalette.border)
+            Divider().overlay(pal.border)
             HStack(spacing: HudSpacing.md) {
                 HudButton("Show HUD", icon: "macwindow", style: .secondary, action: onShowHUD)
                 Text(settings.hotkeyDisplay)
                     .font(HudFont.mono(HudTextSize.xs))
-                    .foregroundStyle(HudPalette.dim)
+                    .foregroundStyle(pal.dim)
                 Spacer()
                 iconButton(
                     settings.soundEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill",
@@ -283,7 +312,7 @@ struct MenuPopoverView: View {
             Text(title)
                 .font(HudFont.mono(HudTextSize.micro, weight: .bold))
                 .tracking(1.5)
-                .foregroundStyle(HudPalette.dim)
+                .foregroundStyle(pal.dim)
             content()
         }
     }
@@ -303,14 +332,14 @@ struct MenuPopoverView: View {
                 .minimumScaleFactor(0.75)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, HudSpacing.sm)
-                .foregroundStyle(selected ? tint : HudPalette.muted)
+                .foregroundStyle(selected ? tint : pal.muted)
                 .background(
                     RoundedRectangle(cornerRadius: HudRadius.standard)
-                        .fill(selected ? HudSurface.tintFill(tint) : HudSurface.inset)
+                        .fill(selected ? tintFill(tint) : insetFill)
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: HudRadius.standard)
-                        .stroke(selected ? HudSurface.tintBorder(tint) : HudPalette.border, lineWidth: 1)
+                        .stroke(selected ? tintBorder(tint) : pal.border, lineWidth: 1)
                 )
         }
         .buttonStyle(.plain)
@@ -328,13 +357,13 @@ struct MenuPopoverView: View {
         Button(action: action) {
             Image(systemName: symbol)
                 .font(HudFont.ui(HudTextSize.sm, weight: .semibold))
-                .foregroundStyle(active ? HudPalette.muted : HudPalette.dim)
+                .foregroundStyle(active ? pal.muted : pal.dim)
                 .frame(width: 28, height: 28)
                 .background(
-                    RoundedRectangle(cornerRadius: HudRadius.standard).fill(HudSurface.inset)
+                    RoundedRectangle(cornerRadius: HudRadius.standard).fill(insetFill)
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: HudRadius.standard).stroke(HudPalette.border, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: HudRadius.standard).stroke(pal.border, lineWidth: 1)
                 )
         }
         .buttonStyle(.plain)

--- a/apps/macos/Sources/Pomo/Settings/SettingsView.swift
+++ b/apps/macos/Sources/Pomo/Settings/SettingsView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 import HudsonUI
 
-/// Compact settings surface, opened from the menu bar (or ⌘, in the HUD). Native
-/// controls dressed in Hudson tokens for a consistent look.
+/// The Settings window — a resizable, two-pane surface (sidebar nav + detail)
+/// that follows the system light/dark appearance via `AppPalette`. Native
+/// controls dressed in adaptive tokens, grouped into cards. Opened from the
+/// menu bar or ⌘, in the HUD.
 struct SettingsView: View {
     @Bindable var settings: PomoSettings
     var account: AccountStatus
@@ -14,150 +16,282 @@ struct SettingsView: View {
     var onSignOut: () -> Void = {}
     var onImportLogin: () -> Void = {}
 
+    @Environment(\.colorScheme) private var scheme
+    @State private var tab: SettingsTab = .general
+
+    private var pal: AppPalette { .resolve(scheme) }
+
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: HudSpacing.xxl) {
-                header
+        HStack(spacing: 0) {
+            sidebar
+            Rectangle().fill(pal.hairline).frame(width: 1)
+            detail
+        }
+        .frame(minWidth: 640, idealWidth: 720, maxWidth: .infinity,
+               minHeight: 480, idealHeight: 560, maxHeight: .infinity)
+        .background(pal.bg)
+    }
 
-                section("DURATIONS") {
-                    stepperRow("Focus", value: settings.binding(\.focusMinutes), suffix: "min")
-                    stepperRow("Short break", value: settings.binding(\.shortBreakMinutes), suffix: "min")
-                    stepperRow("Long break", value: settings.binding(\.longBreakMinutes), suffix: "min")
-                    stepperRow("Long break every", value: settings.binding(\.longBreakInterval), suffix: "sessions", range: 2...8)
-                    toggleRow("Auto-start next session", isOn: settings.binding(\.autoStartNext))
+    // MARK: - Sidebar
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: HudSpacing.sm) {
+                Image(systemName: "hourglass")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(pal.accent)
+                Text("Pomo")
+                    .font(HudFont.mono(HudTextSize.md, weight: .semibold))
+                    .foregroundStyle(pal.ink)
+            }
+            // Clear the window's traffic-light controls (transparent titlebar).
+            .padding(.top, 34)
+            .padding(.horizontal, HudSpacing.lg)
+            .padding(.bottom, HudSpacing.lg)
+
+            VStack(spacing: 2) {
+                ForEach(SettingsTab.allCases) { item in
+                    navRow(item)
                 }
+            }
+            .padding(.horizontal, HudSpacing.sm)
 
-                section("APPEARANCE") {
-                    HStack {
-                        rowLabel("Watchface")
-                        Spacer()
-                        Picker("", selection: settings.binding(\.watchface)) {
-                            ForEach(Watchface.allCases) { face in
-                                Text(face.displayName).tag(face)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .labelsHidden()
-                        .frame(width: 150)
+            Spacer(minLength: HudSpacing.lg)
+
+            if let version = Self.appVersion {
+                Text("Version \(version)")
+                    .font(HudFont.mono(HudTextSize.micro))
+                    .foregroundStyle(pal.dim)
+                    .padding(.horizontal, HudSpacing.lg)
+                    .padding(.bottom, HudSpacing.lg)
+            }
+        }
+        .frame(width: 190)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .background(pal.sidebar)
+    }
+
+    private func navRow(_ item: SettingsTab) -> some View {
+        let selected = item == tab
+        return Button { tab = item } label: {
+            HStack(spacing: HudSpacing.sm) {
+                Image(systemName: item.icon)
+                    .font(.system(size: 12, weight: .medium))
+                    .frame(width: 18)
+                    .foregroundStyle(selected ? pal.action : pal.muted)
+                Text(item.title)
+                    .font(HudFont.ui(HudTextSize.sm, weight: selected ? .semibold : .regular))
+                    .foregroundStyle(selected ? pal.ink : pal.muted)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, HudSpacing.md)
+            .padding(.vertical, HudSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: HudRadius.standard)
+                    .fill(selected ? pal.surfaceHover : .clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Detail
+
+    private var detail: some View {
+        VStack(spacing: 0) {
+            hero
+            Rectangle().fill(pal.hairline).frame(height: 1)
+            ScrollView {
+                VStack(alignment: .leading, spacing: HudSpacing.xl) {
+                    switch tab {
+                    case .general:    generalTab
+                    case .appearance: appearanceTab
+                    case .audio:      audioTab
+                    case .shortcuts:  shortcutsTab
                     }
-                    sliderRow("Opacity", value: settings.binding(\.panelOpacity), range: 0.4...1.0)
-                    sliderRow("Background blur", value: settings.binding(\.backgroundBlur), range: 0.0...1.0)
                 }
+                .padding(HudSpacing.xxl)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(pal.bg)
+    }
 
-                section("SOUND") {
-                    toggleRow("Completion chime", isOn: settings.binding(\.soundEnabled))
-                    sliderRow("Volume", value: settings.binding(\.volume), range: 0.0...1.0)
-                        .opacity(settings.soundEnabled ? 1 : 0.4)
-                        .disabled(!settings.soundEnabled)
+    private var hero: some View {
+        HStack(alignment: .center, spacing: HudSpacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(tab.title)
+                    .font(HudFont.mono(HudTextSize.lg, weight: .semibold))
+                    .foregroundStyle(pal.ink)
+                Text(tab.subtitle)
+                    .font(HudFont.ui(HudTextSize.xs))
+                    .foregroundStyle(pal.dim)
+            }
+            Spacer()
+            button("Done", kind: .primary) { onClose() }
+        }
+        .padding(.horizontal, HudSpacing.xxl)
+        .padding(.top, 30)
+        .padding(.bottom, HudSpacing.lg)
+    }
+
+    // MARK: - Tabs
+
+    private var generalTab: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            group("DURATIONS") {
+                row("Focus") { stepperControl(settings.binding(\.focusMinutes), suffix: "min") }
+                rowDivider
+                row("Short break") { stepperControl(settings.binding(\.shortBreakMinutes), suffix: "min") }
+                rowDivider
+                row("Long break") { stepperControl(settings.binding(\.longBreakMinutes), suffix: "min") }
+                rowDivider
+                row("Long break every") { stepperControl(settings.binding(\.longBreakInterval), suffix: "sessions", range: 2...8) }
+                rowDivider
+                row("Auto-start next session") { toggle(settings.binding(\.autoStartNext)) }
+            }
+
+            group("SOUND") {
+                row("Completion chime") { toggle(settings.binding(\.soundEnabled)) }
+                rowDivider
+                row("Volume") { sliderControl(settings.binding(\.volume)) }
+                    .opacity(settings.soundEnabled ? 1 : 0.4)
+                    .disabled(!settings.soundEnabled)
+            }
+        }
+    }
+
+    private var appearanceTab: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            group("WATCHFACE") {
+                row("Style") {
+                    Picker("", selection: settings.binding(\.watchface)) {
+                        ForEach(Watchface.allCases) { face in
+                            Text(face.displayName).tag(face)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .frame(width: 160)
                 }
+            }
 
-                section("BACKGROUND AUDIO") {
+            group("HUD") {
+                row("Opacity") { sliderControl(settings.binding(\.panelOpacity), range: 0.4...1.0) }
+                rowDivider
+                row("Background blur") { sliderControl(settings.binding(\.backgroundBlur), range: 0.0...1.0) }
+            }
+        }
+    }
+
+    private var audioTab: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            group("BACKGROUND AUDIO") {
+                VStack(alignment: .leading, spacing: HudSpacing.lg) {
                     BrandTextField(
                         text: settings.binding(\.audioURL),
                         placeholder: "Paste a YouTube link…",
-                        textColor: HudPalette.ink,
-                        selectionColor: PomoBrand.accent
+                        textColor: pal.ink,
+                        selectionColor: pal.action
                     )
-                        .padding(.horizontal, HudSpacing.lg)
-                        .frame(height: 30)
-                        .background(
-                            RoundedRectangle(cornerRadius: HudRadius.standard)
-                                .fill(HudPalette.bg)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: HudRadius.standard)
-                                        .stroke(HudPalette.border, lineWidth: 1)
-                                )
-                        )
+                    .padding(.horizontal, HudSpacing.md)
+                    .frame(height: 32)
+                    .background(
+                        RoundedRectangle(cornerRadius: HudRadius.standard)
+                            .fill(pal.inset)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: HudRadius.standard)
+                                    .stroke(pal.border, lineWidth: 1)
+                            )
+                    )
 
-                    HStack(spacing: HudSpacing.md) {
-                        HudButton("Play", icon: "play.fill", style: .primary(.green)) {
-                            onAudioPlay(settings.audioURL)
-                        }
-                        HudButton("Pause", icon: "pause.fill", style: .secondary) { onAudioPause() }
-                        HudButton("Stop", style: .secondary) { onAudioStop() }
+                    HStack(spacing: HudSpacing.sm) {
+                        button("Play", icon: "play.fill", kind: .primary) { onAudioPlay(settings.audioURL) }
+                        button("Pause", icon: "pause.fill") { onAudioPause() }
+                        button("Stop") { onAudioStop() }
                         Spacer()
                     }
 
-                    sliderRow("Volume", value: settings.binding(\.audioVolume), range: 0.0...1.0)
+                    HStack(spacing: HudSpacing.sm) {
+                        Image(systemName: "speaker.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(pal.dim)
+                        Slider(value: settings.binding(\.audioVolume), in: 0...1)
+                            .controlSize(.small)
+                            .tint(pal.action)
+                        Image(systemName: "speaker.wave.3.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(pal.dim)
+                    }
 
                     Text("Audio only — no video. Works with playlists & live streams.")
-                        .font(HudFont.mono(HudTextSize.xs))
-                        .foregroundStyle(HudPalette.dim)
+                        .font(HudFont.ui(HudTextSize.xs))
+                        .foregroundStyle(pal.dim)
                 }
+                .padding(HudSpacing.lg)
+            }
 
-                section("YOUTUBE ACCOUNT") {
-                    HStack(spacing: HudSpacing.md) {
-                        accountAvatar
-                            .frame(width: 30, height: 30)
-                            .clipShape(Circle())
-                            .overlay(Circle().stroke(HudPalette.border, lineWidth: 1))
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(account.signedIn ? (account.name ?? "Signed in") : "Not signed in")
-                                .font(HudFont.mono(HudTextSize.sm))
-                                .foregroundStyle(HudPalette.ink)
-                            Text(account.signedIn ? "Ad-free with Premium" : "Sign in to skip ads")
-                                .font(HudFont.mono(HudTextSize.xs))
-                                .foregroundStyle(HudPalette.dim)
-                        }
-                        Spacer()
-                        if account.signedIn {
-                            HudButton("Sign out", style: .secondary, action: onSignOut)
-                        } else {
-                            HudButton("Sign in", icon: "person.crop.circle", style: .primary(.green), action: onSignIn)
-                        }
+            group("YOUTUBE ACCOUNT") {
+                HStack(spacing: HudSpacing.md) {
+                    accountAvatar
+                        .frame(width: 32, height: 32)
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(pal.border, lineWidth: 1))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(account.signedIn ? (account.name ?? "Signed in") : "Not signed in")
+                            .font(HudFont.ui(HudTextSize.sm, weight: .medium))
+                            .foregroundStyle(pal.ink)
+                        Text(account.signedIn ? "Ad-free with Premium" : "Sign in to skip ads")
+                            .font(HudFont.ui(HudTextSize.xs))
+                            .foregroundStyle(pal.dim)
                     }
-                    HStack {
-                        HudButton("Import login from browser", style: .secondary, action: onImportLogin)
-                        Spacer()
+                    Spacer()
+                    if account.signedIn {
+                        button("Sign out") { onSignOut() }
+                    } else {
+                        button("Sign in", icon: "person.crop.circle", kind: .primary) { onSignIn() }
                     }
                 }
+                .padding(HudSpacing.lg)
 
-                section("SHORTCUT") {
-                    HStack {
-                        rowLabel("Summon HUD")
-                        Spacer()
-                        HotkeyRecorder(display: settings.hotkeyDisplay) { keyCode, modifiers, label in
-                            settings.setHotkey(keyCode: keyCode, modifiers: modifiers, display: label)
-                        }
-                    }
-                    Text("Press a combination including ⌘, ⌥, or ⌃.")
-                        .font(HudFont.mono(HudTextSize.xs))
-                        .foregroundStyle(HudPalette.dim)
-                }
-
-                Divider().overlay(HudPalette.border)
+                rowDivider
 
                 HStack {
-                    Text("Summon the HUD with \(settings.hotkeyDisplay)")
-                        .font(HudFont.mono(HudTextSize.xs))
-                        .foregroundStyle(HudPalette.dim)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Import login from browser")
+                            .font(HudFont.ui(HudTextSize.sm))
+                            .foregroundStyle(pal.ink)
+                        Text("Reuse a YouTube session you're already signed into.")
+                            .font(HudFont.ui(HudTextSize.xs))
+                            .foregroundStyle(pal.dim)
+                    }
                     Spacer()
-                    HudButton("Done", style: .primary(.green)) { onClose() }
+                    button("Import…") { onImportLogin() }
+                }
+                .padding(HudSpacing.lg)
+            }
+        }
+    }
+
+    private var shortcutsTab: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            group("SUMMON HUD") {
+                row("Shortcut", subtitle: "Press a combination including ⌘, ⌥, or ⌃.") {
+                    HotkeyRecorder(display: settings.hotkeyDisplay) { keyCode, modifiers, label in
+                        settings.setHotkey(keyCode: keyCode, modifiers: modifiers, display: label)
+                    }
                 }
             }
-            .padding(HudSpacing.huge)
-        }
-        .frame(width: 380, height: 740)
-        .background(HudPalette.bg)
-        .environment(\.hudTheme, .default)
-    }
 
-    private var header: some View {
-        HStack(spacing: HudSpacing.md) {
-            Image(systemName: "hourglass")
-                .foregroundStyle(HudPalette.accent)
-            Text("Pomo")
-                .font(HudFont.mono(HudTextSize.lg, weight: .semibold))
-                .foregroundStyle(HudPalette.ink)
-            Spacer()
-            Text("Settings")
-                .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
-                .tracking(2)
-                .foregroundStyle(HudPalette.muted)
+            Text("The HUD floats above your work; summon and dismiss it with \(settings.hotkeyDisplay).")
+                .font(HudFont.ui(HudTextSize.xs))
+                .foregroundStyle(pal.dim)
+                .padding(.horizontal, HudSpacing.xs)
         }
     }
 
-    // MARK: - Building blocks
+    // MARK: - Account avatar
 
     @ViewBuilder private var accountAvatar: some View {
         if let img = account.avatar {
@@ -165,72 +299,151 @@ struct SettingsView: View {
         } else {
             Image(systemName: account.signedIn ? "person.crop.circle.fill" : "person.crop.circle")
                 .resizable().aspectRatio(contentMode: .fit)
-                .foregroundStyle(account.signedIn ? PomoBrand.accent : HudPalette.dim)
+                .foregroundStyle(account.signedIn ? pal.action : pal.dim)
         }
     }
 
-    private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: HudSpacing.lg) {
+    // MARK: - Building blocks
+
+    /// A titled group: a dim mono eyebrow over a bordered card.
+    private func group<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: HudSpacing.sm) {
             Text(title)
                 .font(HudFont.mono(HudTextSize.xxs, weight: .bold))
-                .tracking(2)
-                .foregroundStyle(HudPalette.dim)
-            VStack(alignment: .leading, spacing: HudSpacing.md) {
-                content()
-            }
-            .padding(HudSpacing.xl)
-            .background(
-                RoundedRectangle(cornerRadius: HudRadius.card)
-                    .fill(HudPalette.surface)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: HudRadius.card)
-                            .stroke(HudPalette.border, lineWidth: 1)
-                    )
-            )
+                .tracking(1.5)
+                .foregroundStyle(pal.dim)
+            VStack(spacing: 0) { content() }
+                .background(
+                    RoundedRectangle(cornerRadius: HudRadius.card).fill(pal.surface)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: HudRadius.card).stroke(pal.border, lineWidth: 1)
+                )
         }
     }
 
-    private func rowLabel(_ text: String) -> some View {
-        Text(text)
-            .font(HudFont.ui(HudTextSize.sm))
-            .foregroundStyle(HudPalette.ink)
+    /// A label (+ optional subtitle) on the left, a control on the right.
+    private func row<Trailing: View>(
+        _ label: String,
+        subtitle: String? = nil,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        HStack(spacing: HudSpacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(HudFont.ui(HudTextSize.sm))
+                    .foregroundStyle(pal.ink)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(HudFont.ui(HudTextSize.xs))
+                        .foregroundStyle(pal.dim)
+                }
+            }
+            Spacer(minLength: HudSpacing.lg)
+            trailing()
+        }
+        .padding(.horizontal, HudSpacing.lg)
+        .padding(.vertical, HudSpacing.md)
     }
 
-    private func stepperRow(_ label: String, value: Binding<Int>, suffix: String, range: ClosedRange<Int> = 1...99) -> some View {
-        HStack {
-            rowLabel(label)
-            Spacer()
+    private var rowDivider: some View {
+        Rectangle()
+            .fill(pal.hairline)
+            .frame(height: 1)
+            .padding(.leading, HudSpacing.lg)
+    }
+
+    private func stepperControl(_ value: Binding<Int>, suffix: String, range: ClosedRange<Int> = 1...99) -> some View {
+        HStack(spacing: HudSpacing.sm) {
             Text("\(value.wrappedValue) \(suffix)")
                 .font(HudFont.mono(HudTextSize.sm, weight: .medium))
-                .foregroundStyle(HudPalette.muted)
-                .frame(minWidth: 92, alignment: .trailing)
+                .foregroundStyle(pal.muted)
+                .frame(minWidth: 86, alignment: .trailing)
             Stepper("", value: value, in: range)
                 .labelsHidden()
         }
     }
 
-    private func toggleRow(_ label: String, isOn: Binding<Bool>) -> some View {
-        HStack {
-            rowLabel(label)
-            Spacer()
-            Toggle("", isOn: isOn)
-                .labelsHidden()
-                .toggleStyle(.switch)
-                .tint(HudPalette.accent)
+    private func toggle(_ isOn: Binding<Bool>) -> some View {
+        Toggle("", isOn: isOn)
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .controlSize(.small)
+            .tint(pal.action)
+    }
+
+    private func sliderControl(_ value: Binding<Double>, range: ClosedRange<Double> = 0.0...1.0) -> some View {
+        HStack(spacing: HudSpacing.md) {
+            Slider(value: value, in: range)
+                .frame(width: 170)
+                .controlSize(.small)
+                .tint(pal.action)
+            Text("\(Int(value.wrappedValue * 100))%")
+                .font(HudFont.mono(HudTextSize.xs, weight: .medium))
+                .foregroundStyle(pal.muted)
+                .frame(width: 38, alignment: .trailing)
         }
     }
 
-    private func sliderRow(_ label: String, value: Binding<Double>, range: ClosedRange<Double>) -> some View {
-        HStack {
-            rowLabel(label)
-            Spacer()
-            Slider(value: value, in: range)
-                .frame(width: 180)
-                .tint(HudPalette.accent)
-            Text("\(Int(value.wrappedValue * 100))%")
-                .font(HudFont.mono(HudTextSize.xs, weight: .medium))
-                .foregroundStyle(HudPalette.muted)
-                .frame(width: 38, alignment: .trailing)
+    private enum ButtonKind { case primary, secondary }
+
+    private func button(_ title: String, icon: String? = nil, kind: ButtonKind = .secondary, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: HudSpacing.xs) {
+                if let icon {
+                    Image(systemName: icon).font(.system(size: 10, weight: .semibold))
+                }
+                Text(title).font(HudFont.mono(HudTextSize.xs, weight: .semibold))
+            }
+            .foregroundStyle(kind == .primary ? Color.black.opacity(0.82) : pal.ink)
+            .padding(.horizontal, HudSpacing.md)
+            .padding(.vertical, HudSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: HudRadius.standard)
+                    .fill(kind == .primary ? pal.action : pal.inset)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: HudRadius.standard)
+                            .stroke(kind == .primary ? Color.clear : pal.border, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private static let appVersion: String? =
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+}
+
+/// Settings navigation sections.
+enum SettingsTab: String, CaseIterable, Identifiable {
+    case general, appearance, audio, shortcuts
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .general:    return "General"
+        case .appearance: return "Appearance"
+        case .audio:      return "Audio"
+        case .shortcuts:  return "Shortcuts"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .general:    return "gauge.with.dots.needle.50percent"
+        case .appearance: return "paintbrush"
+        case .audio:      return "music.note"
+        case .shortcuts:  return "command"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .general:    return "Session lengths, auto-start, and the completion chime."
+        case .appearance: return "Watchface and HUD panel treatment."
+        case .audio:      return "Background audio and your YouTube account."
+        case .shortcuts:  return "The global hotkey that summons the HUD."
         }
     }
 }


### PR DESCRIPTION
Two related pieces of Pomo's light/dark adaptation.

**Settings redesign — verified light + dark.** Replaces the cramped fixed 380×740 scroll with a System-Settings-style layout: a sidebar (General / Appearance / Audio / Shortcuts) + a detail pane of grouped cards, in a **resizable** window (720×560 default, 640×480 min) with a transparent full-height titlebar. Marked non-restorable so it always opens on General. Colours come from a new **`AppPalette`** — Pomo's own explicit light + dark surface ramp (the Lattices approach) — so it adapts without leaning on Hudson's fixed-dark tokens or its unfinished `lightDraft`. Confirmed via screenshots in both appearances, including a live appearance flip.

**Menu-bar popover.** `MenuPopoverView` follows `colorScheme`: reads the Hudson theme palette, swaps the frosted material `.hudWindow`↔`.popover`, adds scheme-aware inset/tint surfaces, and drops the forced `.darkAqua`. Compiles. This one still rides Hudson's `lightDraft` palette and hasn't been independently screenshotted — a follow-up can migrate it onto `AppPalette` so the whole app shares one mechanism.

_Note: `AppPalette.swift` is shared byte-identical with #16; whichever merges first, the other drops its copy on rebase._