### PR TITLE
✨ Add a right-click menu + login-import panel to the video pane

### DIFF
--- a/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
@@ -1,5 +1,6 @@
 import WebKit
 import AppKit
+import SwiftUI
 
 /// Plays YouTube / YouTube Music audio by driving the **real watch page's
 /// `<video>` element** in a small on-screen "mini-player" window. The IFrame
@@ -21,6 +22,7 @@ final class WebAudioPlayer: NSObject {
     private var navProxy: NavProxy?          // retained — navigationDelegate is weak
     private var messageProxy: MessageProxy?
     private var signInWindow: NSWindow?
+    private var importLoginWindow: NSWindow?
 
     private(set) var isPlaying = false
     private(set) var currentURL: String = ""
@@ -396,21 +398,28 @@ final class WebAudioPlayer: NSObject {
     /// and reload signed-in. Clears any prior Google/YouTube cookies first so
     /// accounts/profiles don't mix. `browser` nil = all; `profile` e.g. "Profile 1".
     func importCookies(fromBrowser browser: String?, profile: String?) {
+        Task { @MainActor in _ = await importLogin(fromBrowser: browser, profile: profile) }
+    }
+
+    /// Awaitable import that returns how many auth cookies were found, so callers
+    /// (e.g. the import panel) can report success vs "nothing found". Clears any
+    /// prior Google/YouTube cookies first so accounts/profiles don't mix.
+    @discardableResult
+    func importLogin(fromBrowser browser: String?, profile: String?) async -> Int {
         ensureWebView()
-        guard let webView else { return }
+        guard let webView else { return 0 }
         let label = [browser, profile].compactMap { $0 }.joined(separator: " / ")
         log("importing cookies from \(label.isEmpty ? "all browsers" : label)…")
-        Task { @MainActor in
-            let store = webView.configuration.websiteDataStore.httpCookieStore
-            let cleared = await Self.clearAuthCookies(store)
-            let cookies = await CookieImporter.cookies(fromBrowser: browser, profile: profile)
-            for cookie in cookies { await store.setCookie(cookie) }
-            self.authUser = 0   // a profile's default account is the intended one
-            self.log("cleared \(cleared), imported \(cookies.count) cookies")
-            if !self.currentURL.isEmpty, let base = Self.watchURL(from: self.currentURL) {
-                webView.load(URLRequest(url: Self.withAuthUser(base, 0)))
-            }
+        let store = webView.configuration.websiteDataStore.httpCookieStore
+        let cleared = await Self.clearAuthCookies(store)
+        let cookies = await CookieImporter.cookies(fromBrowser: browser, profile: profile)
+        for cookie in cookies { await store.setCookie(cookie) }
+        authUser = 0   // a profile's default account is the intended one
+        log("cleared \(cleared), imported \(cookies.count) cookies")
+        if !currentURL.isEmpty, let base = Self.watchURL(from: currentURL) {
+            webView.load(URLRequest(url: Self.withAuthUser(base, 0)))
         }
+        return cookies.count
     }
 
     /// Sign out: drop all Google/YouTube cookies and reload.
@@ -438,6 +447,83 @@ final class WebAudioPlayer: NSObject {
     private static func isAuthDomain(_ domain: String) -> Bool {
         let d = domain.lowercased()
         return d.contains("youtube.com") || d.contains("google.com") || d.contains("google.")
+    }
+
+    // MARK: - Video-pane context menu + import panel
+
+    /// Right-click menu shown over the drawer's video pane (see `DrawerWebView`).
+    /// A compact Pomo surface — transport, open-in-browser, and account actions —
+    /// in place of WebKit's default web context menu.
+    func makeContextMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        addItem(to: menu, isPlaying ? "Pause" : "Play", #selector(ctxTogglePlay))
+        addItem(to: menu, "Next", #selector(ctxNext))
+        addItem(to: menu, "Previous", #selector(ctxPrevious))
+        menu.addItem(.separator())
+        addItem(to: menu, "Open in Browser", #selector(ctxOpenInBrowser))
+        addItem(to: menu, "Hide Video", #selector(ctxHideVideo))
+        menu.addItem(.separator())
+
+        if account.signedIn {
+            let who = NSMenuItem(title: "Signed in\(account.name.map { " as \($0)" } ?? "")",
+                                 action: nil, keyEquivalent: "")
+            who.isEnabled = false
+            menu.addItem(who)
+            addItem(to: menu, "Sign Out", #selector(ctxSignOut))
+        } else {
+            addItem(to: menu, "Sign In to YouTube…", #selector(ctxSignIn))
+        }
+        addItem(to: menu, "Import Login from Browser…", #selector(ctxImportLogin))
+        return menu
+    }
+
+    private func addItem(to menu: NSMenu, _ title: String, _ action: Selector) {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        menu.addItem(item)
+    }
+
+    @objc private func ctxTogglePlay() {
+        if isPlaying {
+            pause()
+        } else {
+            eval("(function(){var v=document.querySelector('video,audio'); if(v){v.play();}})();")
+            isPlaying = true
+        }
+        onStateChange?()
+    }
+    @objc private func ctxNext() { next() }
+    @objc private func ctxPrevious() { previous() }
+    @objc private func ctxOpenInBrowser() { openInBrowser() }
+    @objc private func ctxHideVideo() { setWindowVisible(false) }
+    @objc private func ctxSignIn() { signIn() }
+    @objc private func ctxSignOut() { clearLogin() }
+    @objc private func ctxImportLogin() { showImportLogin() }
+
+    /// A tiny, guided window for importing a browser login (see `CookieImportPanel`).
+    func showImportLogin() {
+        NSApp.setActivationPolicy(.regular)
+        if let importLoginWindow {
+            NSApp.activate(ignoringOtherApps: true)
+            importLoginWindow.makeKeyAndOrderFront(nil)
+            return
+        }
+        let view = CookieImportPanel(
+            account: account,
+            onImport: { [weak self] browser in await self?.importLogin(fromBrowser: browser, profile: nil) ?? 0 },
+            onClose: { [weak self] in self?.importLoginWindow?.close() }
+        )
+        let window = NSWindow(contentViewController: NSHostingController(rootView: view))
+        window.title = "Import YouTube Login"
+        window.styleMask = [.titled, .closable]
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+        window.center()
+        importLoginWindow = window
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
     }
 
     // MARK: - Web view plumbing
@@ -506,7 +592,8 @@ final class WebAudioPlayer: NSObject {
             )
 
             let frame = NSRect(x: 0, y: 0, width: 360, height: 244)
-            let wv = WKWebView(frame: frame, configuration: config)
+            let wv = DrawerWebView(frame: frame, configuration: config)
+            wv.owner = self
             wv.customUserAgent = Self.desktopUA
             let navProxy = NavProxy(self)
             self.navProxy = navProxy
@@ -786,9 +873,14 @@ final class WebAudioPlayer: NSObject {
 
 extension WebAudioPlayer: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        guard (notification.object as? NSWindow) === signInWindow else { return }
-        signInWindow = nil
-        NSApp.setActivationPolicy(.accessory)
+        let window = notification.object as? NSWindow
+        if window === signInWindow {
+            signInWindow = nil
+            NSApp.setActivationPolicy(.accessory)
+        } else if window === importLoginWindow {
+            importLoginWindow = nil
+            NSApp.setActivationPolicy(.accessory)
+        }
     }
 }
 
@@ -809,5 +901,18 @@ private final class NavProxy: NSObject, WKNavigationDelegate {
     }
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         Task { @MainActor in self.owner?.didFinishNavigation() }
+    }
+}
+
+/// The drawer's video pane. Right-click shows a compact Pomo menu (transport +
+/// account actions) rather than WebKit's default web context menu.
+final class DrawerWebView: WKWebView {
+    weak var owner: WebAudioPlayer?
+
+    override func rightMouseDown(with event: NSEvent) {
+        MainActor.assumeIsolated {
+            guard let menu = owner?.makeContextMenu() else { return }
+            menu.popUp(positioning: nil, at: convert(event.locationInWindow, from: nil), in: self)
+        }
     }
 }

--- a/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
@@ -458,30 +458,35 @@ final class WebAudioPlayer: NSObject {
         let menu = NSMenu()
         menu.autoenablesItems = false
 
-        addItem(to: menu, isPlaying ? "Pause" : "Play", #selector(ctxTogglePlay))
-        addItem(to: menu, "Next", #selector(ctxNext))
-        addItem(to: menu, "Previous", #selector(ctxPrevious))
+        addItem(to: menu, isPlaying ? "Pause" : "Play", #selector(ctxTogglePlay),
+                icon: isPlaying ? "pause.fill" : "play.fill")
+        addItem(to: menu, "Next", #selector(ctxNext), icon: "forward.end.fill")
+        addItem(to: menu, "Previous", #selector(ctxPrevious), icon: "backward.end.fill")
         menu.addItem(.separator())
-        addItem(to: menu, "Open in Browser", #selector(ctxOpenInBrowser))
-        addItem(to: menu, "Hide Video", #selector(ctxHideVideo))
+        addItem(to: menu, "Open in Browser", #selector(ctxOpenInBrowser), icon: "safari")
+        addItem(to: menu, "Hide Video", #selector(ctxHideVideo), icon: "eye.slash")
         menu.addItem(.separator())
 
         if account.signedIn {
             let who = NSMenuItem(title: "Signed in\(account.name.map { " as \($0)" } ?? "")",
                                  action: nil, keyEquivalent: "")
             who.isEnabled = false
+            who.image = NSImage(systemSymbolName: "person.crop.circle.fill", accessibilityDescription: nil)
             menu.addItem(who)
-            addItem(to: menu, "Sign Out", #selector(ctxSignOut))
+            addItem(to: menu, "Sign Out", #selector(ctxSignOut), icon: "rectangle.portrait.and.arrow.right")
         } else {
-            addItem(to: menu, "Sign In to YouTube…", #selector(ctxSignIn))
+            addItem(to: menu, "Sign In to YouTube…", #selector(ctxSignIn), icon: "person.crop.circle.badge.plus")
         }
-        addItem(to: menu, "Import Login from Browser…", #selector(ctxImportLogin))
+        addItem(to: menu, "Import Login from Browser…", #selector(ctxImportLogin), icon: "key.horizontal")
         return menu
     }
 
-    private func addItem(to menu: NSMenu, _ title: String, _ action: Selector) {
+    private func addItem(to menu: NSMenu, _ title: String, _ action: Selector, icon: String? = nil) {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
         item.target = self
+        if let icon {
+            item.image = NSImage(systemSymbolName: icon, accessibilityDescription: nil)
+        }
         menu.addItem(item)
     }
 
@@ -518,6 +523,10 @@ final class WebAudioPlayer: NSObject {
         let window = NSWindow(contentViewController: NSHostingController(rootView: view))
         window.title = "Import YouTube Login"
         window.styleMask = [.titled, .closable]
+        // The panel draws its own titled header, so hide the window title (and
+        // blend the titlebar into the content) to avoid showing it twice.
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
         window.isReleasedWhenClosed = false
         window.delegate = self
         window.center()

--- a/apps/macos/Sources/Pomo/Core/AppPalette.swift
+++ b/apps/macos/Sources/Pomo/Core/AppPalette.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// Pomo's adaptive surface palette — the colours for app **windows** (Settings,
+/// Stats) that sit against the user's desktop and therefore follow the system
+/// light/dark appearance.
+///
+/// Hudson's `HudPalette` / `HudSurface` are deliberately fixed-dark (they dress
+/// the always-dark HUD), so we can't lean on them here. Rather than depend on a
+/// framework "light" palette of unknown completeness, Pomo owns both ends of the
+/// ramp explicitly — the same approach the Lattices app takes with its `Palette`.
+/// Dark values mirror the HUD's near-black glass; light values are a clean,
+/// System-Settings-flavoured on-light treatment.
+struct AppPalette {
+    /// Detail / content background.
+    let bg: Color
+    /// Sidebar background (slightly offset from `bg` for separation).
+    let sidebar: Color
+    /// Raised card fill.
+    let surface: Color
+    /// Hover / selected row fill.
+    let surfaceHover: Color
+    /// Recessed control fill (text fields, icon buttons).
+    let inset: Color
+    /// Primary text.
+    let ink: Color
+    /// Secondary text.
+    let muted: Color
+    /// Tertiary text / disabled.
+    let dim: Color
+    /// Card / control borders.
+    let border: Color
+    /// Hairline dividers (lighter than `border`).
+    let hairline: Color
+    /// Brand accent (Pomo yellow) — used sparingly, e.g. the hourglass.
+    let accent: Color
+    /// Functional action accent (green) — primary buttons, toggles, sliders.
+    let action: Color
+
+    static let dark = AppPalette(
+        bg:           Color(hex: 0x161618),
+        sidebar:      Color(hex: 0x111113),
+        surface:      Color(hex: 0x202023),
+        surfaceHover: Color(hex: 0x2A2A2E),
+        inset:        Color(hex: 0x0D0D0F),
+        ink:          Color.white.opacity(0.92),
+        muted:        Color.white.opacity(0.60),
+        dim:          Color.white.opacity(0.40),
+        border:       Color.white.opacity(0.08),
+        hairline:     Color.white.opacity(0.06),
+        accent:       PomoBrand.accent,
+        action:       Color(hex: 0x3DD66B)
+    )
+
+    static let light = AppPalette(
+        bg:           Color(hex: 0xF5F5F7),
+        sidebar:      Color(hex: 0xECECEE),
+        surface:      Color(hex: 0xFFFFFF),
+        surfaceHover: Color.black.opacity(0.045),
+        inset:        Color.black.opacity(0.05),
+        ink:          Color(hex: 0x1B1B20),
+        muted:        Color.black.opacity(0.56),
+        dim:          Color.black.opacity(0.40),
+        border:       Color.black.opacity(0.10),
+        hairline:     Color.black.opacity(0.07),
+        accent:       PomoBrand.accent,
+        action:       Color(hex: 0x27B257)
+    )
+
+    static func resolve(_ scheme: ColorScheme) -> AppPalette {
+        scheme == .light ? .light : .dark
+    }
+}

--- a/apps/macos/Sources/Pomo/Settings/CookieImportPanel.swift
+++ b/apps/macos/Sources/Pomo/Settings/CookieImportPanel.swift
@@ -7,6 +7,7 @@ import HudsonUI
 /// then confirm the identity off the reloaded page.
 ///
 /// Three states: choose a browser → working → result (signed-in / nothing found).
+/// Follows the system light/dark appearance via `AppPalette`, like Settings.
 struct CookieImportPanel: View {
     var account: AccountStatus
     /// Imports auth cookies from the given browser id; returns how many it found.
@@ -33,6 +34,10 @@ struct CookieImportPanel: View {
     @State private var pickedName = ""
     @State private var importedCount = 0
     @State private var confirmed = false
+    @State private var hovered: String?
+
+    @Environment(\.colorScheme) private var scheme
+    private var pal: AppPalette { .resolve(scheme) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: HudSpacing.xl) {
@@ -44,18 +49,23 @@ struct CookieImportPanel: View {
             }
         }
         .padding(HudSpacing.huge)
-        .frame(width: 340)
-        .background(HudPalette.bg)
-        .environment(\.hudTheme, .default)
+        .frame(width: 360)
+        .background(pal.bg)
     }
 
     private var header: some View {
         HStack(spacing: HudSpacing.md) {
             Image(systemName: "key.horizontal.fill")
-                .foregroundStyle(PomoBrand.accent)
-            Text("Import YouTube Login")
-                .font(HudFont.mono(HudTextSize.lg, weight: .semibold))
-                .foregroundStyle(HudPalette.ink)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(pal.accent)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Import YouTube Login")
+                    .font(HudFont.mono(HudTextSize.md, weight: .semibold))
+                    .foregroundStyle(pal.ink)
+                Text("Go ad-free with a session you already have")
+                    .font(HudFont.ui(HudTextSize.xs))
+                    .foregroundStyle(pal.dim)
+            }
         }
     }
 
@@ -64,8 +74,8 @@ struct CookieImportPanel: View {
     private var chooseStep: some View {
         VStack(alignment: .leading, spacing: HudSpacing.lg) {
             Text("Borrow the login from a browser you're already signed into — the player goes ad-free with Premium.")
-                .font(HudFont.mono(HudTextSize.xs))
-                .foregroundStyle(HudPalette.dim)
+                .font(HudFont.ui(HudTextSize.xs))
+                .foregroundStyle(pal.muted)
                 .fixedSize(horizontal: false, vertical: true)
 
             VStack(spacing: HudSpacing.sm) {
@@ -76,43 +86,45 @@ struct CookieImportPanel: View {
 
             HStack {
                 Spacer()
-                HudButton("Cancel", style: .secondary, action: onClose)
+                button("Cancel", action: onClose)
             }
         }
     }
 
     private func browserRow(_ browser: Browser) -> some View {
-        Button { start(browser) } label: {
+        let isHovered = hovered == browser.id
+        return Button { start(browser) } label: {
             HStack(spacing: HudSpacing.md) {
                 Image(systemName: "globe")
                     .font(HudFont.ui(HudTextSize.sm))
-                    .foregroundStyle(HudPalette.muted)
+                    .foregroundStyle(isHovered ? pal.action : pal.muted)
                     .frame(width: 18)
                 Text(browser.name)
-                    .font(HudFont.mono(HudTextSize.sm, weight: .medium))
-                    .foregroundStyle(HudPalette.ink)
+                    .font(HudFont.ui(HudTextSize.sm, weight: .medium))
+                    .foregroundStyle(pal.ink)
                 Spacer()
                 if let note = browser.note {
                     Text(note)
                         .font(HudFont.mono(HudTextSize.micro))
-                        .foregroundStyle(HudPalette.dim)
+                        .foregroundStyle(pal.dim)
                 }
                 Image(systemName: "chevron.right")
                     .font(HudFont.ui(HudTextSize.micro, weight: .semibold))
-                    .foregroundStyle(HudPalette.dim)
+                    .foregroundStyle(pal.dim)
             }
             .padding(.horizontal, HudSpacing.lg)
-            .frame(height: 38)
+            .frame(height: 40)
             .background(
                 RoundedRectangle(cornerRadius: HudRadius.standard)
-                    .fill(HudSurface.inset)
+                    .fill(isHovered ? pal.surfaceHover : pal.inset)
                     .overlay(
                         RoundedRectangle(cornerRadius: HudRadius.standard)
-                            .stroke(HudPalette.border, lineWidth: 1)
+                            .stroke(isHovered ? pal.action.opacity(0.5) : pal.border, lineWidth: 1)
                     )
             )
         }
         .buttonStyle(.plain)
+        .onHover { hovered = $0 ? browser.id : (hovered == browser.id ? nil : hovered) }
     }
 
     // MARK: - Step 2 · working
@@ -121,13 +133,13 @@ struct CookieImportPanel: View {
         VStack(spacing: HudSpacing.lg) {
             ProgressView()
                 .controlSize(.large)
-                .tint(PomoBrand.accent)
+                .tint(pal.action)
             Text("Reading your login from \(pickedName)…")
-                .font(HudFont.mono(HudTextSize.sm))
-                .foregroundStyle(HudPalette.muted)
+                .font(HudFont.ui(HudTextSize.sm))
+                .foregroundStyle(pal.muted)
             Text("Chrome-based browsers may ask for Keychain access.")
-                .font(HudFont.mono(HudTextSize.micro))
-                .foregroundStyle(HudPalette.dim)
+                .font(HudFont.ui(HudTextSize.xs))
+                .foregroundStyle(pal.dim)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, HudSpacing.xxl)
@@ -140,12 +152,12 @@ struct CookieImportPanel: View {
             VStack(spacing: HudSpacing.lg) {
                 avatar
                 Text("Signed in as \(account.name ?? "your account")")
-                    .font(HudFont.mono(HudTextSize.sm, weight: .semibold))
-                    .foregroundStyle(HudPalette.ink)
+                    .font(HudFont.ui(HudTextSize.sm, weight: .semibold))
+                    .foregroundStyle(pal.ink)
                 Label("Ad-free with Premium", systemImage: "checkmark.seal.fill")
-                    .font(HudFont.mono(HudTextSize.xs))
-                    .foregroundStyle(PomoBrand.accent)
-                HudButton("Done", style: .primary(.green), action: onClose)
+                    .font(HudFont.ui(HudTextSize.xs, weight: .medium))
+                    .foregroundStyle(pal.action)
+                button("Done", kind: .primary, action: onClose)
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, HudSpacing.lg)
@@ -157,21 +169,21 @@ struct CookieImportPanel: View {
                         : "No YouTube login found in \(pickedName).",
                     systemImage: importedCount > 0 ? "exclamationmark.triangle.fill" : "xmark.circle.fill"
                 )
-                .font(HudFont.mono(HudTextSize.xs))
-                .foregroundStyle(HudPalette.muted)
+                .font(HudFont.ui(HudTextSize.sm))
+                .foregroundStyle(pal.muted)
                 .fixedSize(horizontal: false, vertical: true)
 
                 Text(importedCount > 0
                     ? "Try playing a video — the page may still be signing in."
                     : "Make sure you're logged into YouTube in that browser, or pick another.")
-                    .font(HudFont.mono(HudTextSize.micro))
-                    .foregroundStyle(HudPalette.dim)
+                    .font(HudFont.ui(HudTextSize.xs))
+                    .foregroundStyle(pal.dim)
                     .fixedSize(horizontal: false, vertical: true)
 
                 HStack {
-                    HudButton("Try another", style: .secondary) { phase = .choose }
+                    button("Try another") { phase = .choose }
                     Spacer()
-                    HudButton("Close", style: .secondary, action: onClose)
+                    button("Close", action: onClose)
                 }
             }
         }
@@ -184,12 +196,35 @@ struct CookieImportPanel: View {
             } else {
                 Image(systemName: "person.crop.circle.fill")
                     .resizable().aspectRatio(contentMode: .fit)
-                    .foregroundStyle(PomoBrand.accent)
+                    .foregroundStyle(pal.action)
             }
         }
         .frame(width: 48, height: 48)
         .clipShape(Circle())
-        .overlay(Circle().stroke(HudPalette.border, lineWidth: 1))
+        .overlay(Circle().stroke(pal.border, lineWidth: 1))
+    }
+
+    // MARK: - Button
+
+    private enum ButtonKind { case primary, secondary }
+
+    private func button(_ title: String, kind: ButtonKind = .secondary, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
+                .foregroundStyle(kind == .primary ? Color.black.opacity(0.82) : pal.ink)
+                .padding(.horizontal, HudSpacing.lg)
+                .padding(.vertical, HudSpacing.sm)
+                .background(
+                    RoundedRectangle(cornerRadius: HudRadius.standard)
+                        .fill(kind == .primary ? pal.action : pal.inset)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: HudRadius.standard)
+                                .stroke(kind == .primary ? Color.clear : pal.border, lineWidth: 1)
+                        )
+                )
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Flow

--- a/apps/macos/Sources/Pomo/Settings/CookieImportPanel.swift
+++ b/apps/macos/Sources/Pomo/Settings/CookieImportPanel.swift
@@ -1,0 +1,215 @@
+import SwiftUI
+import HudsonUI
+
+/// A tiny, guided panel for borrowing a YouTube login from a browser the user is
+/// already signed into — so the web player goes ad-free (Premium) without a fresh
+/// sign-in. Pick a browser, we read its cookies via the `pomo-cookies` helper,
+/// then confirm the identity off the reloaded page.
+///
+/// Three states: choose a browser → working → result (signed-in / nothing found).
+struct CookieImportPanel: View {
+    var account: AccountStatus
+    /// Imports auth cookies from the given browser id; returns how many it found.
+    var onImport: (String) async -> Int
+    var onClose: () -> Void
+
+    private struct Browser: Identifiable {
+        let id: String
+        let name: String
+        let note: String?
+    }
+
+    private let browsers: [Browser] = [
+        .init(id: "chrome",  name: "Chrome",  note: "Keychain prompt"),
+        .init(id: "brave",   name: "Brave",   note: "Keychain prompt"),
+        .init(id: "arc",     name: "Arc",     note: nil),
+        .init(id: "edge",    name: "Edge",    note: nil),
+        .init(id: "firefox", name: "Firefox", note: nil),
+        .init(id: "safari",  name: "Safari",  note: "Full Disk Access"),
+    ]
+
+    private enum Phase { case choose, working, done }
+    @State private var phase: Phase = .choose
+    @State private var pickedName = ""
+    @State private var importedCount = 0
+    @State private var confirmed = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xl) {
+            header
+            switch phase {
+            case .choose:  chooseStep
+            case .working: workingStep
+            case .done:    resultStep
+            }
+        }
+        .padding(HudSpacing.huge)
+        .frame(width: 340)
+        .background(HudPalette.bg)
+        .environment(\.hudTheme, .default)
+    }
+
+    private var header: some View {
+        HStack(spacing: HudSpacing.md) {
+            Image(systemName: "key.horizontal.fill")
+                .foregroundStyle(PomoBrand.accent)
+            Text("Import YouTube Login")
+                .font(HudFont.mono(HudTextSize.lg, weight: .semibold))
+                .foregroundStyle(HudPalette.ink)
+        }
+    }
+
+    // MARK: - Step 1 · choose
+
+    private var chooseStep: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.lg) {
+            Text("Borrow the login from a browser you're already signed into — the player goes ad-free with Premium.")
+                .font(HudFont.mono(HudTextSize.xs))
+                .foregroundStyle(HudPalette.dim)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: HudSpacing.sm) {
+                ForEach(browsers) { browser in
+                    browserRow(browser)
+                }
+            }
+
+            HStack {
+                Spacer()
+                HudButton("Cancel", style: .secondary, action: onClose)
+            }
+        }
+    }
+
+    private func browserRow(_ browser: Browser) -> some View {
+        Button { start(browser) } label: {
+            HStack(spacing: HudSpacing.md) {
+                Image(systemName: "globe")
+                    .font(HudFont.ui(HudTextSize.sm))
+                    .foregroundStyle(HudPalette.muted)
+                    .frame(width: 18)
+                Text(browser.name)
+                    .font(HudFont.mono(HudTextSize.sm, weight: .medium))
+                    .foregroundStyle(HudPalette.ink)
+                Spacer()
+                if let note = browser.note {
+                    Text(note)
+                        .font(HudFont.mono(HudTextSize.micro))
+                        .foregroundStyle(HudPalette.dim)
+                }
+                Image(systemName: "chevron.right")
+                    .font(HudFont.ui(HudTextSize.micro, weight: .semibold))
+                    .foregroundStyle(HudPalette.dim)
+            }
+            .padding(.horizontal, HudSpacing.lg)
+            .frame(height: 38)
+            .background(
+                RoundedRectangle(cornerRadius: HudRadius.standard)
+                    .fill(HudSurface.inset)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: HudRadius.standard)
+                            .stroke(HudPalette.border, lineWidth: 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Step 2 · working
+
+    private var workingStep: some View {
+        VStack(spacing: HudSpacing.lg) {
+            ProgressView()
+                .controlSize(.large)
+                .tint(PomoBrand.accent)
+            Text("Reading your login from \(pickedName)…")
+                .font(HudFont.mono(HudTextSize.sm))
+                .foregroundStyle(HudPalette.muted)
+            Text("Chrome-based browsers may ask for Keychain access.")
+                .font(HudFont.mono(HudTextSize.micro))
+                .foregroundStyle(HudPalette.dim)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, HudSpacing.xxl)
+    }
+
+    // MARK: - Step 3 · result
+
+    @ViewBuilder private var resultStep: some View {
+        if confirmed {
+            VStack(spacing: HudSpacing.lg) {
+                avatar
+                Text("Signed in as \(account.name ?? "your account")")
+                    .font(HudFont.mono(HudTextSize.sm, weight: .semibold))
+                    .foregroundStyle(HudPalette.ink)
+                Label("Ad-free with Premium", systemImage: "checkmark.seal.fill")
+                    .font(HudFont.mono(HudTextSize.xs))
+                    .foregroundStyle(PomoBrand.accent)
+                HudButton("Done", style: .primary(.green), action: onClose)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, HudSpacing.lg)
+        } else {
+            VStack(alignment: .leading, spacing: HudSpacing.lg) {
+                Label(
+                    importedCount > 0
+                        ? "Imported \(importedCount) cookies from \(pickedName), but couldn't confirm the sign-in."
+                        : "No YouTube login found in \(pickedName).",
+                    systemImage: importedCount > 0 ? "exclamationmark.triangle.fill" : "xmark.circle.fill"
+                )
+                .font(HudFont.mono(HudTextSize.xs))
+                .foregroundStyle(HudPalette.muted)
+                .fixedSize(horizontal: false, vertical: true)
+
+                Text(importedCount > 0
+                    ? "Try playing a video — the page may still be signing in."
+                    : "Make sure you're logged into YouTube in that browser, or pick another.")
+                    .font(HudFont.mono(HudTextSize.micro))
+                    .foregroundStyle(HudPalette.dim)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack {
+                    HudButton("Try another", style: .secondary) { phase = .choose }
+                    Spacer()
+                    HudButton("Close", style: .secondary, action: onClose)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var avatar: some View {
+        Group {
+            if let img = account.avatar {
+                Image(nsImage: img).resizable().aspectRatio(contentMode: .fill)
+            } else {
+                Image(systemName: "person.crop.circle.fill")
+                    .resizable().aspectRatio(contentMode: .fit)
+                    .foregroundStyle(PomoBrand.accent)
+            }
+        }
+        .frame(width: 48, height: 48)
+        .clipShape(Circle())
+        .overlay(Circle().stroke(HudPalette.border, lineWidth: 1))
+    }
+
+    // MARK: - Flow
+
+    private func start(_ browser: Browser) {
+        pickedName = browser.name
+        confirmed = false
+        importedCount = 0
+        phase = .working
+        Task {
+            let count = await onImport(browser.id)
+            importedCount = count
+            // The reload + masthead read is async; give it a moment to confirm.
+            if count > 0 {
+                for _ in 0..<24 where !account.signedIn {
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                }
+            }
+            confirmed = account.signedIn
+            phase = .done
+        }
+    }
+}


### PR DESCRIPTION
Right-clicking the video drawer opens a compact Pomo menu instead of WebKit's default web menu (via a `DrawerWebView` subclass): Play/Pause, Next, Previous, Open in Browser, Hide Video, and account actions (Sign in / Sign out, or "Signed in as <name>") — each now with an SF Symbol icon.

**Import Login from Browser…** opens a small guided panel (`CookieImportPanel`): pick a browser → "Reading your login from <X>…" → result (signed-in avatar/name, or "no login found" with retry). Backed by an awaitable `importLogin(fromBrowser:profile:)` that returns the imported cookie count. The panel now follows the system light/dark appearance via the shared **`AppPalette`** (verified in light), and hides its redundant window title so only its own header shows.

The panel is reached entirely through normal features — the right-click menu, the Settings button, and the existing `importCookies` CLI/URL command — no dev affordances.

_Note: `AppPalette.swift` is shared byte-identical with #15._