### PR TITLE
🔧 Give local dev builds a distinct `.dev` bundle id

### DIFF
--- a/apps/macos/scripts/build-dmg.sh
+++ b/apps/macos/scripts/build-dmg.sh
@@ -128,7 +128,11 @@ if [[ "$build_app" == true ]]; then
     run_args+=(--sign "$sign_identity")
   fi
 
-  POMO_APP_PATH="$app_path" POMO_VERSION="$version" "$repo_root/scripts/run-app.sh" "${run_args[@]}"
+  # DMG/release builds carry the canonical bundle id + name (not the dev `.dev`
+  # default) so signing, notarization, and installs match the shipped app.
+  POMO_APP_PATH="$app_path" POMO_VERSION="$version" \
+    POMO_BUNDLE_ID="${POMO_BUNDLE_ID:-dev.pomo.hud}" POMO_DISPLAY_NAME="${POMO_DISPLAY_NAME:-Pomo}" \
+    "$repo_root/scripts/run-app.sh" "${run_args[@]}"
 elif [[ "$skip_sign" != "1" ]]; then
   echo "Signing $app_path"
   codesign --force --deep --options runtime --timestamp --sign "$sign_identity" "$app_path"

--- a/apps/macos/scripts/run-app.sh
+++ b/apps/macos/scripts/run-app.sh
@@ -9,7 +9,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 app_name="Pomo"
-bundle_id="dev.pomo.hud"
+# Local dev builds get a `.dev` bundle id + label so they don't collide with an
+# installed Pomo — LaunchServices would otherwise dedupe launches (and `pomo://`
+# routing) to the wrong copy. DMG/release builds (build-dmg.sh) override these
+# back to the canonical id, so signing / notarization / installs are unaffected.
+bundle_id="${POMO_BUNDLE_ID:-dev.pomo.hud.dev}"
+display_name="${POMO_DISPLAY_NAME:-Pomo Dev}"
 app_path="${POMO_APP_PATH:-$repo_root/dist/$app_name.app}"
 version="${POMO_VERSION:-0.1.0}"
 configuration=release
@@ -166,7 +171,9 @@ cat > "$app_path/Contents/Info.plist" <<PLIST
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>
-  <string>$app_name</string>
+  <string>$display_name</string>
+  <key>CFBundleDisplayName</key>
+  <string>$display_name</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Local `run-app.sh` builds shared the `dev.pomo.hud` bundle id with an installed Pomo, so LaunchServices deduped launches (and `pomo://` routing) to the wrong copy — dev builds could hijack, or be hijacked by, `/Applications/Pomo.app`.

- **run-app.sh** defaults to `dev.pomo.hud.dev` + name **"Pomo Dev"** (overridable via `POMO_BUNDLE_ID` / `POMO_DISPLAY_NAME`); executable + app dir stay `Pomo`.
- **build-dmg.sh** forces canonical `dev.pomo.hud` / "Pomo" for any DMG, so signing / notarization / installs are unchanged.

Verified: `run-app.sh` → `CFBundleIdentifier=dev.pomo.hud.dev`; `POMO_BUNDLE_ID=dev.pomo.hud run-app.sh` (build-dmg path) → `dev.pomo.hud`.

Tradeoff: a `.dev` build gets its own WebKit data store, so it starts signed-out rather than sharing the installed app's YouTube login (cleaner for dev).