### PR TITLE
💄 Lead the browser import list with the most-common browsers

### DIFF
--- a/apps/cli/bin/pomo.js
+++ b/apps/cli/bin/pomo.js
@@ -214,8 +214,10 @@ async function install(args) {
 
 /** Detected Chromium-family browser profiles, for cookie import. */
 function browserProfiles() {
+  // Most-common first, so the browsers people actually use lead the picker.
   const bases = [
     ['chrome', 'Google/Chrome'],
+    ['edge', 'Microsoft Edge'],
     ['brave', 'BraveSoftware/Brave-Browser'],
     ['chromium', 'Chromium'],
   ];

--- a/apps/macos/Sources/Pomo/Settings/CookieImportPanel.swift
+++ b/apps/macos/Sources/Pomo/Settings/CookieImportPanel.swift
@@ -20,13 +20,14 @@ struct CookieImportPanel: View {
         let note: String?
     }
 
+    // Ordered most-common first so the browsers people actually use lead the list.
     private let browsers: [Browser] = [
         .init(id: "chrome",  name: "Chrome",  note: "Keychain prompt"),
+        .init(id: "safari",  name: "Safari",  note: "Full Disk Access"),
+        .init(id: "firefox", name: "Firefox", note: nil),
+        .init(id: "edge",    name: "Edge",    note: nil),
         .init(id: "brave",   name: "Brave",   note: "Keychain prompt"),
         .init(id: "arc",     name: "Arc",     note: nil),
-        .init(id: "edge",    name: "Edge",    note: nil),
-        .init(id: "firefox", name: "Firefox", note: nil),
-        .init(id: "safari",  name: "Safari",  note: "Full Disk Access"),
     ]
 
     private enum Phase { case choose, working, done }


### PR DESCRIPTION
The cookie-import browser list was in an arbitrary order (Chrome, Brave, Arc, Edge, Firefox, Safari) — with the niche browsers above Safari and Firefox. Reorder both surfaces to lead with the browsers people actually use:

- **Settings panel** (`CookieImportPanel`): Chrome → Safari → Firefox → Edge → Brave → Arc.
- **CLI** (`pomo login import`): the Chromium-profile picker now leads with Chrome and includes **Edge** (previously only chrome/brave/chromium were detected).

Pure ordering change — no change to the import mechanism or the underlying `pomo-cookies` helper, which already supports all of these.