### PR TITLE
🐛 Make login + import work from the Settings page

### DIFF
--- a/apps/macos/Sources/Pomo/AppDelegate.swift
+++ b/apps/macos/Sources/Pomo/AppDelegate.swift
@@ -261,7 +261,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             onAudioStop: { [weak self] in self?.audio.stop() },
             onSignIn: { [weak self] in self?.audio.signIn() },
             onSignOut: { [weak self] in self?.audio.clearLogin() },
-            onImportLogin: { [weak self] in self?.audio.importCookies(browser: nil, profile: nil) }
+            onImportLogin: { [weak self] in self?.audio.showImportLogin() }
         )
         let window = NSWindow(contentViewController: NSHostingController(rootView: view))
         window.title = "Pomo Settings"

--- a/apps/macos/Sources/Pomo/Audio/AudioController.swift
+++ b/apps/macos/Sources/Pomo/Audio/AudioController.swift
@@ -43,6 +43,7 @@ final class AudioController {
     func next() { web.next() }
     func previous() { web.previous() }
     func signIn() { web.signIn() }
+    func showImportLogin() { web.showImportLogin() }
     func importCookies(browser: String?, profile: String?) { web.importCookies(fromBrowser: browser, profile: profile) }
     func clearLogin() { web.clearLogin() }
     func setAccount(_ index: Int) { web.setAccount(index) }

--- a/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
@@ -436,6 +436,16 @@ final class WebAudioPlayer: NSObject {
         }
     }
 
+    /// Reload the player's current page so a freshly-acquired login is detected.
+    /// The signed-in identity is read off the *player's* masthead, not the
+    /// sign-in window, so without this a web sign-in never registers. No-op when
+    /// nothing is loaded (there's no page to read the account from yet).
+    private func reloadForLogin() {
+        guard let webView, !currentURL.isEmpty, let base = Self.watchURL(from: currentURL) else { return }
+        authUser = 0
+        webView.load(URLRequest(url: Self.withAuthUser(base, 0)))
+    }
+
     @discardableResult
     private static func clearAuthCookies(_ store: WKHTTPCookieStore) async -> Int {
         let existing = await store.allCookies()
@@ -886,6 +896,10 @@ extension WebAudioPlayer: NSWindowDelegate {
         if window === signInWindow {
             signInWindow = nil
             NSApp.setActivationPolicy(.accessory)
+            // The account is read off the *player's* page, not the sign-in
+            // window, so reload the player to pick up the freshly-signed-in
+            // session (otherwise a web sign-in never registers in the app).
+            reloadForLogin()
         } else if window === importLoginWindow {
             importLoginWindow = nil
             NSApp.setActivationPolicy(.accessory)


### PR DESCRIPTION
The YouTube account actions in Settings worked from the CLI but not the UI.

**Import did nothing visible.** The Settings "Import…" button called `audio.importCookies(browser: nil, profile: nil)` — a silent, headless, all-browser cookie import with no browser picker and no feedback. Now it opens `showImportLogin()`, the same browser-picker panel the video pane's right-click menu uses (Chrome/Safari/Firefox/Edge/Brave/Arc → progress → result). Re-adds the `AudioController.showImportLogin` passthrough for it.

**Sign in never registered.** The signed-in identity is read off the *player's* page, not the sign-in window — but `windowWillClose` for the sign-in window only nil'd it and never reloaded the player, so a successful web sign-in stayed invisible to the app. Now it reloads the player on close (no-op when nothing's loaded), the same thing the working import path does.