### PR TITLE
💄 macOS HUD polish + login persistence + CLI targeting

### DIFF
--- a/apps/cli/bin/pomo.js
+++ b/apps/cli/bin/pomo.js
@@ -13,6 +13,7 @@ import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSy
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
+import { fileURLToPath } from 'node:url';
 
 const REPO = 'arach/pomo';
 const STATE_FILE = join(homedir(), 'Library', 'Application Support', 'Pomo', 'state.json');
@@ -31,11 +32,29 @@ function requireMac() {
   if (process.platform !== 'darwin') die('this CLI only works on macOS.');
 }
 
+/**
+ * Which Pomo.app should handle a `pomo://` command. With many stale bundles
+ * registered (old worktrees, mounted DMGs, cached builds), bare `open pomo://`
+ * routes unpredictably to "some older version". So:
+ *   1. honour an explicit POMO_APP env override, else
+ *   2. when this CLI lives inside the repo, prefer its sibling dev build, so
+ *      `pomo` drives the copy you're hacking on — not whatever LaunchServices
+ *      happens to pick.
+ * Returns null for a plain npm install (no sibling app) → default routing.
+ */
+function targetApp() {
+  if (process.env.POMO_APP) return process.env.POMO_APP;
+  const devApp = join(fileURLToPath(import.meta.url), '../../../macos/dist/Pomo.app');
+  return existsSync(devApp) ? devApp : null;
+}
+
 /** Fire a pomo:// command at the app via `open`. */
 function send(path) {
   requireMac();
+  const url = `pomo://${path}`;
+  const app = targetApp();
   try {
-    execFileSync('open', [`pomo://${path}`], { stdio: 'ignore' });
+    execFileSync('open', app ? ['-a', app, url] : [url], { stdio: 'ignore' });
   } catch {
     die(`couldn't reach Pomo. Is it installed? Try: pomo install`);
   }

--- a/apps/macos/Sources/Pomo/AppDelegate.swift
+++ b/apps/macos/Sources/Pomo/AppDelegate.swift
@@ -97,6 +97,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // so refresh the state file whenever it does.
         audio.onStateChange = { [weak self] in self?.writeState() }
 
+        // Let the video menu's "Change Track" submenu list favorites.
+        audio.bindFavorites(favorites)
+
         // System-wide summon hotkey (default Hyper+P), configurable in Settings.
         registerSummonHotkey()
 

--- a/apps/macos/Sources/Pomo/Audio/AudioController.swift
+++ b/apps/macos/Sources/Pomo/Audio/AudioController.swift
@@ -33,6 +33,10 @@ final class AudioController {
         web.onStateChange = { [weak self] in self?.notify() }
     }
 
+    /// Hand the player the favorites store so the video menu's "Change Track"
+    /// submenu can list them.
+    func bindFavorites(_ store: FavoritesStore) { web.favorites = store }
+
     func setVolume(_ value: Double) { web.setVolume(value) }
 
     func play(urlString raw: String) { web.play(urlString: raw); notify() }

--- a/apps/macos/Sources/Pomo/Audio/LoginPersistence.swift
+++ b/apps/macos/Sources/Pomo/Audio/LoginPersistence.swift
@@ -1,0 +1,71 @@
+import WebKit
+
+/// On-disk backup of the YouTube/Google login cookies.
+///
+/// WKWebView's default data store *does* persist cookies, but it keys storage by
+/// the app's bundle id (so a dev build and the signed release don't share a
+/// login) and it drops session-only cookies between launches. We sidestep both
+/// by writing the auth cookies to `~/Library/Application Support/Pomo/cookies.json`
+/// — a path shared by every build — and re-injecting them on launch. Login is
+/// left on the drive and reloaded next time, exactly once per change.
+enum CookieJar {
+    /// Shared across bundle ids (the "Pomo" support dir is not id-scoped), so a
+    /// login made in any build is visible to the others.
+    private static let fileURL: URL = {
+        let base = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first ?? FileManager.default.temporaryDirectory
+        let dir = base.appendingPathComponent("Pomo", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("cookies.json")
+    }()
+
+    /// The subset of an `HTTPCookie` we need to rebuild it on the next launch.
+    private struct Stored: Codable {
+        let name: String
+        let value: String
+        let domain: String
+        let path: String
+        let expires: Double?   // seconds since 1970; nil = session cookie
+        let secure: Bool
+    }
+
+    /// Persist the given cookies (caller filters to the auth domains). Written
+    /// owner-only since these are login credentials.
+    static func save(_ cookies: [HTTPCookie]) {
+        let stored = cookies.map {
+            Stored(name: $0.name, value: $0.value, domain: $0.domain, path: $0.path,
+                   expires: $0.expiresDate?.timeIntervalSince1970, secure: $0.isSecure)
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        guard let data = try? encoder.encode(stored) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+    }
+
+    /// Rebuild the saved cookies for re-injection. Expired ones are dropped.
+    static func load() -> [HTTPCookie] {
+        guard let data = try? Data(contentsOf: fileURL),
+              let stored = try? JSONDecoder().decode([Stored].self, from: data)
+        else { return [] }
+        let now = Date()
+        return stored.compactMap { s in
+            if let e = s.expires, Date(timeIntervalSince1970: e) < now { return nil }
+            var props: [HTTPCookiePropertyKey: Any] = [
+                .name: s.name, .value: s.value, .domain: s.domain, .path: s.path,
+            ]
+            if let e = s.expires { props[.expires] = Date(timeIntervalSince1970: e) }
+            if s.secure { props[.secure] = "TRUE" }
+            return HTTPCookie(properties: props)
+        }
+    }
+}
+
+/// Thin `WKHTTPCookieStoreObserver` that forwards change notifications to a
+/// closure (callbacks arrive on the main thread).
+final class CookieStoreObserver: NSObject, WKHTTPCookieStoreObserver {
+    private let onChange: () -> Void
+    init(_ onChange: @escaping () -> Void) { self.onChange = onChange }
+    func cookiesDidChange(in cookieStore: WKHTTPCookieStore) { onChange() }
+}

--- a/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
@@ -53,6 +53,10 @@ final class WebAudioPlayer: NSObject {
     /// Signed-in YouTube identity, surfaced in Settings + the drawer avatar.
     let account = AccountStatus()
 
+    /// Favorites, for the video menu's "Change Track" submenu. Weak — owned by
+    /// AppDelegate; wired via `AudioController.bindFavorites`.
+    weak var favorites: FavoritesStore?
+
     private static let drawerRadius: CGFloat = 12
 
     /// Fired when playback state changes (from JS player events).
@@ -535,9 +539,12 @@ final class WebAudioPlayer: NSObject {
 
         menu.addItem(.separator())
         addItem(to: menu, "Open in Browser", #selector(ctxOpenInBrowser), icon: "safari")
+        menu.addItem(changeTrackItem())
         addItem(to: menu, "Hide Video", #selector(ctxHideVideo), icon: "eye.slash")
         menu.addItem(.separator())
 
+        // Account: once you're signed in, Sign In / Import are irrelevant — show
+        // who you are and a way out. Import is only an alternative sign-in path.
         if account.signedIn {
             let who = NSMenuItem(title: "Signed in\(account.name.map { " as \($0)" } ?? "")",
                                  action: nil, keyEquivalent: "")
@@ -547,8 +554,33 @@ final class WebAudioPlayer: NSObject {
             addItem(to: menu, "Sign Out", #selector(ctxSignOut), icon: "rectangle.portrait.and.arrow.right")
         } else {
             addItem(to: menu, "Sign In to YouTube…", #selector(ctxSignIn), icon: "person.crop.circle.badge.plus")
+            addItem(to: menu, "Import Login from Browser…", #selector(ctxImportLogin), icon: "key.horizontal")
         }
-        addItem(to: menu, "Import Login from Browser…", #selector(ctxImportLogin), icon: "key.horizontal")
+    }
+
+    /// "Change Track ▸" — switch the player to one of your favorites without
+    /// leaving the video. The current track is checked.
+    private func changeTrackItem() -> NSMenuItem {
+        let item = NSMenuItem(title: "Change Track", action: nil, keyEquivalent: "")
+        item.image = NSImage(systemSymbolName: "music.note.list", accessibilityDescription: nil)
+        let sub = NSMenu()
+        sub.autoenablesItems = false
+        let favs = favorites?.items ?? []
+        if favs.isEmpty {
+            let none = NSMenuItem(title: "No favorites yet", action: nil, keyEquivalent: "")
+            none.isEnabled = false
+            sub.addItem(none)
+        } else {
+            for fav in favs {
+                let row = NSMenuItem(title: fav.title, action: #selector(ctxPlayFavorite(_:)), keyEquivalent: "")
+                row.target = self
+                row.representedObject = fav.url
+                row.state = (fav.url == currentURL) ? .on : .off
+                sub.addItem(row)
+            }
+        }
+        item.submenu = sub
+        return item
     }
 
     private func addItem(to menu: NSMenu, _ title: String, _ action: Selector, icon: String? = nil) {
@@ -562,6 +594,10 @@ final class WebAudioPlayer: NSObject {
 
     @objc private func ctxOpenInBrowser() { openInBrowser() }
     @objc private func ctxHideVideo() { setWindowVisible(false) }
+    @objc private func ctxPlayFavorite(_ sender: NSMenuItem) {
+        guard let url = sender.representedObject as? String else { return }
+        play(urlString: url)
+    }
     @objc private func ctxSignIn() { signIn() }
     @objc private func ctxSignOut() { clearLogin() }
     @objc private func ctxImportLogin() { showImportLogin() }

--- a/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
@@ -461,17 +461,20 @@ final class WebAudioPlayer: NSObject {
 
     // MARK: - Video-pane context menu + import panel
 
-    /// Right-click menu shown over the drawer's video pane (see `DrawerWebView`).
-    /// A compact Pomo surface — transport, open-in-browser, and account actions —
-    /// in place of WebKit's default web context menu.
-    func makeContextMenu() -> NSMenu {
-        let menu = NSMenu()
-        menu.autoenablesItems = false
+    /// Augment WebKit's default video context menu rather than replace it: keep
+    /// the useful native items (Mute, Loop, Full Screen, PiP, …), drop the
+    /// redundant "Show Controls" (YouTube has its own controls), and append
+    /// Pomo's open-in-browser, hide, and account actions. Called from
+    /// `DrawerWebView.willOpenMenu`, which is the path WebKit actually uses (an
+    /// `NSView.rightMouseDown` override doesn't intercept web-content menus).
+    func augmentVideoMenu(_ menu: NSMenu) {
+        menu.items
+            .filter {
+                $0.identifier?.rawValue == "WKMenuItemIdentifierToggleVideoControls"
+                    || $0.title.range(of: "controls", options: .caseInsensitive) != nil
+            }
+            .forEach { menu.removeItem($0) }
 
-        addItem(to: menu, isPlaying ? "Pause" : "Play", #selector(ctxTogglePlay),
-                icon: isPlaying ? "pause.fill" : "play.fill")
-        addItem(to: menu, "Next", #selector(ctxNext), icon: "forward.end.fill")
-        addItem(to: menu, "Previous", #selector(ctxPrevious), icon: "backward.end.fill")
         menu.addItem(.separator())
         addItem(to: menu, "Open in Browser", #selector(ctxOpenInBrowser), icon: "safari")
         addItem(to: menu, "Hide Video", #selector(ctxHideVideo), icon: "eye.slash")
@@ -488,7 +491,6 @@ final class WebAudioPlayer: NSObject {
             addItem(to: menu, "Sign In to YouTube…", #selector(ctxSignIn), icon: "person.crop.circle.badge.plus")
         }
         addItem(to: menu, "Import Login from Browser…", #selector(ctxImportLogin), icon: "key.horizontal")
-        return menu
     }
 
     private func addItem(to menu: NSMenu, _ title: String, _ action: Selector, icon: String? = nil) {
@@ -500,17 +502,6 @@ final class WebAudioPlayer: NSObject {
         menu.addItem(item)
     }
 
-    @objc private func ctxTogglePlay() {
-        if isPlaying {
-            pause()
-        } else {
-            eval("(function(){var v=document.querySelector('video,audio'); if(v){v.play();}})();")
-            isPlaying = true
-        }
-        onStateChange?()
-    }
-    @objc private func ctxNext() { next() }
-    @objc private func ctxPrevious() { previous() }
     @objc private func ctxOpenInBrowser() { openInBrowser() }
     @objc private func ctxHideVideo() { setWindowVisible(false) }
     @objc private func ctxSignIn() { signIn() }
@@ -927,15 +918,16 @@ private final class NavProxy: NSObject, WKNavigationDelegate {
     }
 }
 
-/// The drawer's video pane. Right-click shows a compact Pomo menu (transport +
-/// account actions) rather than WebKit's default web context menu.
+/// The drawer's video pane. Right-clicking augments WebKit's native video menu
+/// with Pomo's account + open/hide actions (see `augmentVideoMenu`). We hook
+/// `willOpenMenu` rather than `rightMouseDown` because WebKit builds the
+/// web-content menu through the former; a `rightMouseDown` override is bypassed.
 final class DrawerWebView: WKWebView {
     weak var owner: WebAudioPlayer?
 
-    override func rightMouseDown(with event: NSEvent) {
+    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
         MainActor.assumeIsolated {
-            guard let menu = owner?.makeContextMenu() else { return }
-            menu.popUp(positioning: nil, at: convert(event.locationInWindow, from: nil), in: self)
+            owner?.augmentVideoMenu(menu)
         }
     }
 }

--- a/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/Pomo/Audio/WebAudioPlayer.swift
@@ -58,6 +58,20 @@ final class WebAudioPlayer: NSObject {
     /// Fired when playback state changes (from JS player events).
     var onStateChange: (() -> Void)?
 
+    /// Keeps the on-disk cookie backup in sync, and coalesces the writes so a
+    /// burst of cookie changes during a page load only persists once.
+    private var cookieObserver: CookieStoreObserver?
+    private var cookieSaveWork: DispatchWorkItem?
+
+    override init() {
+        super.init()
+        // Re-seed any login saved on disk into the shared store, then keep that
+        // backup current as cookies change — so login survives relaunches and
+        // even a switch between the dev build and the installed release.
+        restoreSavedLogin()
+        startCookiePersistence()
+    }
+
     // MARK: - Playback
 
     /// Google multi-login account index (0 = default). Persisted so the chosen
@@ -429,6 +443,7 @@ final class WebAudioPlayer: NSObject {
         Task { @MainActor in
             let cleared = await Self.clearAuthCookies(webView.configuration.websiteDataStore.httpCookieStore)
             self.authUser = 0
+            CookieJar.save([])   // write-through so logout survives an immediate quit
             self.log("logout — cleared \(cleared) cookies")
             if !self.currentURL.isEmpty, let url = Self.watchURL(from: self.currentURL) {
                 webView.load(URLRequest(url: url))
@@ -457,6 +472,49 @@ final class WebAudioPlayer: NSObject {
     private static func isAuthDomain(_ domain: String) -> Bool {
         let d = domain.lowercased()
         return d.contains("youtube.com") || d.contains("google.com") || d.contains("google.")
+    }
+
+    // MARK: - Login persistence (cookies on disk)
+
+    /// Re-inject any login saved on a prior run into the shared default store, so
+    /// a one-time sign-in is reloaded on every launch (and across builds).
+    private func restoreSavedLogin() {
+        let saved = CookieJar.load()
+        guard !saved.isEmpty else { return }
+        let store = WKWebsiteDataStore.default().httpCookieStore
+        Task { @MainActor in
+            for cookie in saved { await store.setCookie(cookie) }
+            self.log("restored \(saved.count) login cookies from disk")
+        }
+    }
+
+    /// Watch the shared cookie store and mirror the auth cookies to disk whenever
+    /// they change — so logging in (or out) is written through automatically.
+    private func startCookiePersistence() {
+        let store = WKWebsiteDataStore.default().httpCookieStore
+        let observer = CookieStoreObserver { [weak self] in
+            // Delivered on the main thread; coalesce the burst during a page load.
+            MainActor.assumeIsolated { self?.scheduleCookieSave() }
+        }
+        store.add(observer)
+        cookieObserver = observer
+    }
+
+    private func scheduleCookieSave() {
+        cookieSaveWork?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated { self?.persistAuthCookies() }
+        }
+        cookieSaveWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+    }
+
+    private func persistAuthCookies() {
+        let store = WKWebsiteDataStore.default().httpCookieStore
+        Task { @MainActor in
+            let all = await store.allCookies()
+            CookieJar.save(all.filter { Self.isAuthDomain($0.domain) })
+        }
     }
 
     // MARK: - Video-pane context menu + import panel

--- a/apps/macos/Sources/Pomo/HUD/HUDController.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDController.swift
@@ -36,7 +36,8 @@ final class HUDController {
             rootView: HUDRootView(
                 model: model, settings: settings, audio: audio, favorites: favorites,
                 size: contentSize,
-                onHide: { [weak self] in self?.hide() }
+                onHide: { [weak self] in self?.hide() },
+                onEditingChange: { [weak self] editing in self?.setEditingFocus(editing) }
             )
         )
         hosting.frame = NSRect(origin: .zero, size: contentSize)
@@ -93,6 +94,17 @@ final class HUDController {
     func applyOpacity() {
         guard isShown, let panel else { return }
         panel.alphaValue = CGFloat(settings.panelOpacity)
+    }
+
+    /// While a quick field is open, ramp the panel to full opacity so the editor
+    /// card is crisp; restore the user's opacity when it closes.
+    private func setEditingFocus(_ editing: Bool) {
+        guard isShown, let panel else { return }
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.15
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = editing ? 1.0 : CGFloat(settings.panelOpacity)
+        }
     }
 
     private func positionOnActiveScreen(_ panel: NSPanel) {

--- a/apps/macos/Sources/Pomo/HUD/HUDController.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDController.swift
@@ -33,7 +33,11 @@ final class HUDController {
         if let panel { return panel }
         let panel = HUDPanel(contentSize: contentSize)
         let hosting = NSHostingView(
-            rootView: HUDRootView(model: model, settings: settings, audio: audio, favorites: favorites, size: contentSize)
+            rootView: HUDRootView(
+                model: model, settings: settings, audio: audio, favorites: favorites,
+                size: contentSize,
+                onHide: { [weak self] in self?.hide() }
+            )
         )
         hosting.frame = NSRect(origin: .zero, size: contentSize)
         hosting.autoresizingMask = [.width, .height]

--- a/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
@@ -84,6 +84,12 @@ struct HUDRootView: View {
             // Dims the watchface behind a single focused input; shared across
             // every face so it's one implementation and looks identical.
             QuickEntryOverlay(model: model, settings: settings, audio: audio, favorites: favorites)
+
+            // Glanceable intent — what you're focusing on — pinned at the
+            // bottom of the panel while not editing.
+            if !model.intent.isEmpty, model.quickField == .none {
+                intentBanner
+            }
         }
         .frame(width: size.width, height: size.height)
         .clipShape(panelShape)
@@ -103,6 +109,30 @@ struct HUDRootView: View {
         .environment(\.audioControls, audioFaceControls)
         // Right-click anywhere on the HUD for the quick-entry actions.
         .contextMenu { hudContextMenu }
+    }
+
+    /// A subtle pill showing the current intent, pinned to the bottom of the
+    /// panel so you can see what you're focusing on at a glance.
+    private var intentBanner: some View {
+        VStack {
+            Spacer()
+            HStack(spacing: HudSpacing.xs) {
+                Circle()
+                    .fill(model.sessionType.tint.color)
+                    .frame(width: 5, height: 5)
+                Text(model.intent)
+                    .font(HudFont.mono(HudTextSize.micro, weight: .medium))
+                    .foregroundStyle(Color.white.opacity(0.85))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .padding(.horizontal, HudSpacing.sm)
+            .padding(.vertical, 4)
+            .background(Capsule().fill(Color.black.opacity(0.4)))
+            .overlay(Capsule().stroke(Color.white.opacity(0.08), lineWidth: 1))
+            .padding(.bottom, HudSpacing.sm)
+        }
+        .allowsHitTesting(false)
     }
 
     /// Context menu shown on a right-click / control-click of the HUD. Mirrors
@@ -167,7 +197,9 @@ private struct QuickEntryOverlay: View {
             case .none:
                 fieldFocused = false
             case .intent:
-                draft = model.intent
+                // Start empty (the current intent is shown on the HUD) so the
+                // pre-filled text isn't select-all'd into a harsh highlight.
+                draft = ""
                 fieldFocused = true
             case .video:
                 // Pre-fill from the clipboard when it holds a link, so a copied
@@ -197,20 +229,15 @@ private struct QuickEntryOverlay: View {
 
             Rectangle().fill(HudPalette.border).frame(height: 1)
 
+            // Cancel on the left, the commit action on the right. Return also
+            // commits (the field is focused) and Escape cancels.
             HStack(spacing: HudSpacing.sm) {
-                keyHint("return", "set")
-                Text("·").foregroundStyle(HudPalette.border)
-                keyHint("escape", "cancel")
-                Spacer(minLength: 0)
-                if showsClear {
-                    Button("Clear", action: clear)
-                        .buttonStyle(.plain)
-                        .font(HudFont.mono(HudTextSize.micro, weight: .semibold))
-                        .foregroundStyle(HudPalette.muted)
+                pillButton("Cancel", fill: HudSurface.inset, stroke: HudPalette.border, text: HudPalette.muted) {
+                    model.cancelEditing()
                 }
+                Spacer(minLength: 0)
+                pillButton(primaryLabel, fill: accent, stroke: .clear, text: .black.opacity(0.85), action: commit)
             }
-            .font(HudFont.mono(HudTextSize.micro))
-            .foregroundStyle(HudPalette.dim)
         }
         .padding(HudSpacing.xl)
         .background(
@@ -239,11 +266,10 @@ private struct QuickEntryOverlay: View {
         }
     }
 
-    private var showsClear: Bool {
+    private var primaryLabel: String {
         switch field {
-        case .intent: return !model.intent.isEmpty
-        case .video:  return !settings.audioURL.isEmpty || audio.isPlaying
-        case .none:   return false
+        case .video:         return "Play"
+        case .intent, .none: return "Set"
         }
     }
 
@@ -251,7 +277,8 @@ private struct QuickEntryOverlay: View {
         let text = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         switch field {
         case .intent:
-            model.setIntent(text)
+            // Empty submit keeps the current intent (clear it from the menu).
+            if !text.isEmpty { model.setIntent(text) }
         case .video:
             if text.isEmpty { break }
             settings.audioURL = text
@@ -265,20 +292,17 @@ private struct QuickEntryOverlay: View {
         model.cancelEditing()
     }
 
-    private func clear() {
-        switch field {
-        case .intent: model.setIntent("")
-        case .video:  audio.stop()
-        case .none:   break
+    private func pillButton(_ title: String, fill: Color, stroke: Color, text: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
+                .foregroundStyle(text)
+                .padding(.horizontal, HudSpacing.md)
+                .padding(.vertical, HudSpacing.xs)
+                .background(RoundedRectangle(cornerRadius: HudRadius.tight, style: .continuous).fill(fill))
+                .overlay(RoundedRectangle(cornerRadius: HudRadius.tight, style: .continuous).stroke(stroke, lineWidth: 1))
         }
-        model.cancelEditing()
-    }
-
-    private func keyHint(_ symbol: String, _ label: String) -> some View {
-        HStack(spacing: 3) {
-            Image(systemName: symbol)
-            Text(label)
-        }
+        .buttonStyle(.plain)
     }
 
     private func clipboardURL() -> String? {

--- a/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
@@ -12,6 +12,8 @@ struct HUDRootView: View {
     let audio: AudioController
     let favorites: FavoritesStore
     let size: CGSize
+    /// Dismiss the HUD (right-click → Hide). Wired by HUDController.
+    var onHide: (() -> Void)? = nil
 
     /// The two on-face audio buttons show once a station is configured or
     /// something is playing. Reading `audio`/`settings` here keeps them live.
@@ -176,6 +178,13 @@ struct HUDRootView: View {
         Divider()
 
         Button("Paste Audio / Video Link…") { model.beginEditing(.video) }
+
+        Divider()
+
+        Button("Hide HUD") { onHide?() }
+        // You can't right-click a hidden HUD, so remind them how to bring it back.
+        Button("Reopen with \(settings.hotkeyDisplay)") {}
+            .disabled(true)
     }
 }
 

--- a/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
@@ -85,10 +85,11 @@ struct HUDRootView: View {
             // every face so it's one implementation and looks identical.
             QuickEntryOverlay(model: model, settings: settings, audio: audio, favorites: favorites)
 
-            // Glanceable intent — what you're focusing on — pinned at the
-            // bottom of the panel while not editing.
-            if !model.intent.isEmpty, model.quickField == .none {
-                intentBanner
+            // Music + video drawer buttons, parked in the bottom-right corner so
+            // they're out of the way of the centered transport. Only while a
+            // station is configured/playing and not mid-edit.
+            if audioFaceControls.enabled, model.quickField == .none {
+                audioCornerControls
             }
         }
         .frame(width: size.width, height: size.height)
@@ -111,28 +112,43 @@ struct HUDRootView: View {
         .contextMenu { hudContextMenu }
     }
 
-    /// A subtle pill showing the current intent, pinned to the bottom of the
-    /// panel so you can see what you're focusing on at a glance.
-    private var intentBanner: some View {
-        VStack {
+    /// Music + video buttons docked to the panel's bottom-right corner, neutral
+    /// (face-agnostic) so they read the same on every watchface.
+    private var audioCornerControls: some View {
+        let a = audioFaceControls
+        return VStack {
             Spacer()
-            HStack(spacing: HudSpacing.xs) {
-                Circle()
-                    .fill(model.sessionType.tint.color)
-                    .frame(width: 5, height: 5)
-                Text(model.intent)
-                    .font(HudFont.mono(HudTextSize.micro, weight: .medium))
-                    .foregroundStyle(Color.white.opacity(0.85))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+            HStack {
+                Spacer()
+                HStack(spacing: HudSpacing.sm) {
+                    cornerButton(
+                        systemName: a.isPlaying ? "pause.fill" : "music.note",
+                        help: a.isPlaying ? "Pause music" : "Play music",
+                        action: a.togglePlay
+                    )
+                    cornerButton(
+                        systemName: a.drawerOpen ? "rectangle.fill" : "play.rectangle",
+                        help: a.drawerOpen ? "Hide video" : "Show video",
+                        action: a.toggleDrawer
+                    )
+                }
             }
-            .padding(.horizontal, HudSpacing.sm)
-            .padding(.vertical, 4)
-            .background(Capsule().fill(Color.black.opacity(0.4)))
-            .overlay(Capsule().stroke(Color.white.opacity(0.08), lineWidth: 1))
-            .padding(.bottom, HudSpacing.sm)
         }
-        .allowsHitTesting(false)
+        .padding(HudSpacing.sm)
+    }
+
+    private func cornerButton(systemName: String, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.white.opacity(0.82))
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(Color.white.opacity(0.06)))
+                .overlay(Circle().stroke(Color.white.opacity(0.16), lineWidth: 1))
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .help(help)
     }
 
     /// Context menu shown on a right-click / control-click of the HUD. Mirrors

--- a/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
@@ -14,6 +14,9 @@ struct HUDRootView: View {
     let size: CGSize
     /// Dismiss the HUD (right-click → Hide). Wired by HUDController.
     var onHide: (() -> Void)? = nil
+    /// Editing a quick field → make the panel fully opaque so the card is crisp
+    /// rather than bleeding the face + desktop through the panel's translucency.
+    var onEditingChange: ((Bool) -> Void)? = nil
 
     /// The two on-face audio buttons show once a station is configured or
     /// something is playing. Reading `audio`/`settings` here keeps them live.
@@ -85,7 +88,7 @@ struct HUDRootView: View {
             // Quick-entry fields (press `i` for intent, `v` to paste a link).
             // Dims the watchface behind a single focused input; shared across
             // every face so it's one implementation and looks identical.
-            QuickEntryOverlay(model: model, settings: settings, audio: audio, favorites: favorites)
+            QuickEntryOverlay(model: model, settings: settings, audio: audio, favorites: favorites, onEditingChange: onEditingChange)
 
             // Music + video drawer buttons, parked in the bottom-right corner so
             // they're out of the way of the centered transport. Only while a
@@ -197,6 +200,7 @@ private struct QuickEntryOverlay: View {
     let settings: PomoSettings
     let audio: AudioController
     let favorites: FavoritesStore
+    var onEditingChange: ((Bool) -> Void)? = nil
 
     @State private var draft: String = ""
     @FocusState private var fieldFocused: Bool
@@ -207,9 +211,10 @@ private struct QuickEntryOverlay: View {
     var body: some View {
         ZStack {
             if field != .none {
-                // Scrim — tap anywhere outside the card to cancel.
+                // Scrim — tap anywhere outside the card to cancel. Near-opaque so
+                // the face (and desktop) don't read through behind the editor.
                 Rectangle()
-                    .fill(Color.black.opacity(0.5))
+                    .fill(Color.black.opacity(0.82))
                     .contentShape(Rectangle())
                     .onTapGesture { model.cancelEditing() }
 
@@ -218,6 +223,8 @@ private struct QuickEntryOverlay: View {
         }
         .animation(.easeOut(duration: 0.15), value: field)
         .onChange(of: field) { _, newField in
+            // Drive the panel opaque while editing so the card is crisp.
+            onEditingChange?(newField != .none)
             switch newField {
             case .none:
                 fieldFocused = false
@@ -267,7 +274,7 @@ private struct QuickEntryOverlay: View {
         .padding(HudSpacing.xl)
         .background(
             RoundedRectangle(cornerRadius: HudRadius.standard, style: .continuous)
-                .fill(HudSurface.inset)
+                .fill(Color(white: 0.13))   // solid, not the frosted inset
         )
         .overlay(
             RoundedRectangle(cornerRadius: HudRadius.standard, style: .continuous)

--- a/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
@@ -142,7 +142,7 @@ struct HUDRootView: View {
             Image(systemName: systemName)
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(Color.white.opacity(0.82))
-                .frame(width: 26, height: 26)
+                .frame(width: 28, height: 28)   // matches the transport's secondary buttons
                 .background(Circle().fill(Color.white.opacity(0.06)))
                 .overlay(Circle().stroke(Color.white.opacity(0.16), lineWidth: 1))
                 .contentShape(Circle())

--- a/apps/macos/Sources/Pomo/MenuBar/MenuPopoverView.swift
+++ b/apps/macos/Sources/Pomo/MenuBar/MenuPopoverView.swift
@@ -54,7 +54,7 @@ struct MenuPopoverView: View {
             section("INTENT") { intentField }
             transport
             section("SESSION") { sessionPills }
-            section("WATCHFACE") { watchfaceChips }
+            section("WATCHFACE") { watchfacePicker }
             section("AUDIO") { audioControls }
             footer
         }
@@ -185,79 +185,121 @@ struct MenuPopoverView: View {
         }
     }
 
-    // MARK: - Watchface chips
+    // MARK: - Watchface
 
-    private var watchfaceChips: some View {
-        let columns = Array(
-            repeating: GridItem(.flexible(), spacing: HudSpacing.sm),
-            count: 3
-        )
-        return LazyVGrid(columns: columns, spacing: HudSpacing.sm) {
-            ForEach(Watchface.allCases) { face in
-                chip(
-                    label: face.displayName,
-                    selected: face == settings.watchface,
-                    tint: pal.accent,
-                    enabled: true
-                ) {
-                    settings.watchface = face
-                    settings.saveNow()
+    /// Compact ‹ current › stepper plus a `…` menu for the full list, instead of
+    /// a chip grid of every face.
+    private var watchfacePicker: some View {
+        HStack(spacing: HudSpacing.sm) {
+            iconButton("chevron.left", help: "Previous watchface") { cycleWatchface(-1) }
+            Text(settings.watchface.displayName)
+                .font(HudFont.mono(HudTextSize.sm, weight: .medium))
+                .foregroundStyle(pal.ink)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .frame(maxWidth: .infinity)
+            iconButton("chevron.right", help: "Next watchface") { cycleWatchface(1) }
+            Menu {
+                ForEach(Watchface.allCases) { face in
+                    Button(face.displayName) { setWatchface(face) }
                 }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(HudFont.ui(HudTextSize.sm, weight: .semibold))
+                    .foregroundStyle(pal.muted)
+                    .frame(width: 28, height: 28)
+                    .background(RoundedRectangle(cornerRadius: HudRadius.standard).fill(insetFill))
+                    .overlay(RoundedRectangle(cornerRadius: HudRadius.standard).stroke(pal.border, lineWidth: 1))
+                    .contentShape(Rectangle())
             }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("All watchfaces")
         }
+    }
+
+    private func cycleWatchface(_ delta: Int) {
+        let all = Watchface.allCases
+        guard let i = all.firstIndex(of: settings.watchface) else { return }
+        setWatchface(all[(i + delta + all.count) % all.count])
+    }
+
+    private func setWatchface(_ face: Watchface) {
+        settings.watchface = face
+        settings.saveNow()
     }
 
     // MARK: - Audio
 
+    /// Pared down: a thumbnail of what's playing, the title, a play/pause toggle,
+    /// and a single "Change" menu — no cramped favorites grid or volume slider
+    /// (volume lives in Settings + on the HUD).
     private var audioControls: some View {
-        VStack(alignment: .leading, spacing: HudSpacing.md) {
-            HStack(spacing: HudSpacing.md) {
-                iconButton(
-                    audio.isPlaying ? "pause.fill" : "play.fill",
-                    help: audio.isPlaying ? "Pause" : "Play",
-                    active: audio.isPlaying || !audio.currentURL.isEmpty
-                ) { onToggleAudio() }
-                iconButton("stop.fill", help: "Stop") { onStopAudio() }
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(nowPlayingTitle)
-                        .font(HudFont.mono(HudTextSize.xs, weight: .medium))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .foregroundStyle(audio.currentURL.isEmpty ? pal.dim : pal.ink)
-                    Text(nowPlayingSubtitle)
-                        .font(HudFont.mono(HudTextSize.micro))
-                        .foregroundStyle(audio.isPlaying ? tint.color : pal.dim)
-                }
-                Spacer(minLength: 0)
+        HStack(spacing: HudSpacing.md) {
+            audioThumbnail
+            VStack(alignment: .leading, spacing: 1) {
+                Text(nowPlayingTitle)
+                    .font(HudFont.mono(HudTextSize.xs, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundStyle(audio.currentURL.isEmpty ? pal.dim : pal.ink)
+                Text(nowPlayingSubtitle)
+                    .font(HudFont.mono(HudTextSize.micro))
+                    .foregroundStyle(audio.isPlaying ? tint.color : pal.dim)
             }
-
+            Spacer(minLength: 0)
+            iconButton(
+                audio.isPlaying ? "pause.fill" : "play.fill",
+                help: audio.isPlaying ? "Pause" : "Play",
+                active: audio.isPlaying || !audio.currentURL.isEmpty
+            ) { onToggleAudio() }
             if !favorites.items.isEmpty {
-                let columns = Array(repeating: GridItem(.flexible(), spacing: HudSpacing.sm), count: 2)
-                LazyVGrid(columns: columns, spacing: HudSpacing.sm) {
+                Menu {
                     ForEach(favorites.items) { favorite in
-                        chip(
-                            label: favorite.title,
-                            selected: favorite.url == audio.currentURL,
-                            tint: pal.accent,
-                            enabled: true
-                        ) { onPlayFavorite(favorite) }
+                        Button(favorite.title) { onPlayFavorite(favorite) }
                     }
+                } label: {
+                    HStack(spacing: 3) {
+                        Text("Change")
+                        Image(systemName: "chevron.down").font(HudFont.ui(HudTextSize.micro))
+                    }
+                    .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
+                    .foregroundStyle(pal.muted)
+                    .padding(.horizontal, HudSpacing.sm)
+                    .frame(height: 28)
+                    .background(RoundedRectangle(cornerRadius: HudRadius.standard).fill(insetFill))
+                    .overlay(RoundedRectangle(cornerRadius: HudRadius.standard).stroke(pal.border, lineWidth: 1))
+                    .contentShape(Rectangle())
                 }
-            }
-
-            HStack(spacing: HudSpacing.sm) {
-                Image(systemName: "speaker.fill")
-                    .font(HudFont.ui(HudTextSize.micro))
-                    .foregroundStyle(pal.dim)
-                Slider(value: settings.binding(\.audioVolume), in: 0...1)
-                    .controlSize(.mini)
-                    .tint(tint.color)
-                Image(systemName: "speaker.wave.3.fill")
-                    .font(HudFont.ui(HudTextSize.micro))
-                    .foregroundStyle(pal.dim)
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
             }
         }
+    }
+
+    /// Thumbnail of the playing video (YouTube poster), or a placeholder.
+    @ViewBuilder private var audioThumbnail: some View {
+        let id = WebAudioPlayer.youTubeID(from: audio.currentURL)
+        RoundedRectangle(cornerRadius: HudRadius.standard, style: .continuous)
+            .fill(insetFill)
+            .frame(width: 44, height: 44)
+            .overlay {
+                if let id, let url = URL(string: "https://img.youtube.com/vi/\(id)/mqdefault.jpg") {
+                    AsyncImage(url: url) { phase in
+                        if let image = phase.image {
+                            image.resizable().aspectRatio(contentMode: .fill)
+                        } else {
+                            Image(systemName: "music.note").font(.system(size: 15)).foregroundStyle(pal.dim)
+                        }
+                    }
+                } else {
+                    Image(systemName: "music.note").font(.system(size: 15)).foregroundStyle(pal.dim)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: HudRadius.standard, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: HudRadius.standard, style: .continuous).stroke(pal.border, lineWidth: 1))
     }
 
     private var nowPlayingTitle: String {

--- a/apps/macos/Sources/Pomo/Watchfaces/MinimalFace.swift
+++ b/apps/macos/Sources/Pomo/Watchfaces/MinimalFace.swift
@@ -54,5 +54,15 @@ struct MinimalFace: View {
         }
         .padding(.horizontal, HudSpacing.huge)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Clean dark backing so the face stays legible over a busy desktop —
+        // every other watchface carries its own; minimal was the bare exception
+        // and read as washed-out/see-through. The panel's blur + opacity still
+        // soften it, keeping the frosted depth.
+        .background(
+            LinearGradient(
+                colors: [Color(white: 0.12), Color(white: 0.05)],
+                startPoint: .top, endPoint: .bottom
+            )
+        )
     }
 }

--- a/apps/macos/Sources/Pomo/Watchfaces/MinimalFace.swift
+++ b/apps/macos/Sources/Pomo/Watchfaces/MinimalFace.swift
@@ -10,16 +10,16 @@ struct MinimalFace: View {
 
     var body: some View {
         VStack(spacing: HudSpacing.lg) {
-            // Session label
+            // Session label — your intent once it's named, otherwise the session
+            // type ("FOCUS"). The intent takes the label's place rather than
+            // crowding in alongside it.
             HStack(spacing: HudSpacing.sm) {
-                Circle()
-                    .fill(accent)
-                    .frame(width: 6, height: 6)
-                    .opacity(model.isRunning ? 1 : 0.4)
-                Text(model.sessionType.label)
+                Text(model.intent.isEmpty ? model.sessionType.label : model.intent)
                     .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
-                    .tracking(2)
+                    .tracking(model.intent.isEmpty ? 2 : 0.5)
                     .foregroundStyle(HudPalette.muted)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                 if model.isPaused {
                     Text("· PAUSED")
                         .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
@@ -35,17 +35,6 @@ struct MinimalFace: View {
                 .monospacedDigit()
                 .contentTransition(.numericText())
                 .animation(.snappy(duration: 0.2), value: model.remainingSeconds)
-
-            // Intent — what this session is for, when named.
-            if !model.intent.isEmpty {
-                Text(model.intent)
-                    .font(HudFont.ui(HudTextSize.sm))
-                    .foregroundStyle(HudPalette.muted)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .frame(maxWidth: .infinity)
-                    .transition(.opacity)
-            }
 
             // Progress rule
             GeometryReader { geo in

--- a/apps/macos/Sources/Pomo/Watchfaces/RolodexFace.swift
+++ b/apps/macos/Sources/Pomo/Watchfaces/RolodexFace.swift
@@ -17,13 +17,14 @@ struct RolodexFace: View {
 
     var body: some View {
         VStack(spacing: HudSpacing.lg) {
+            // Your intent once named, otherwise the session type — no status dot.
             HStack(spacing: HudSpacing.sm) {
-                Circle().fill(accent).frame(width: 6, height: 6)
-                    .opacity(model.isRunning ? 1 : 0.4)
-                Text(model.sessionType.label)
+                Text(model.intent.isEmpty ? model.sessionType.label : model.intent)
                     .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
-                    .tracking(2)
+                    .tracking(model.intent.isEmpty ? 2 : 0.5)
                     .foregroundStyle(HudPalette.muted)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
                 if model.isPaused {
                     Text("· PAUSED")
                         .font(HudFont.mono(HudTextSize.xs, weight: .semibold))
@@ -87,7 +88,9 @@ private struct FlipDigit: View {
                 .stroke(Color.white.opacity(0.08), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.4), radius: 3, y: 2)
-        .animation(.spring(response: 0.35, dampingFraction: 0.72), value: value)
+        // The digit holds steady, then flips in one quick, settled snap (no
+        // bounce) — calmer than a continuous spring that's always in motion.
+        .animation(.snappy(duration: 0.16, extraBounce: 0.0), value: value)
     }
 }
 

--- a/apps/macos/Sources/Pomo/Watchfaces/WatchfaceView.swift
+++ b/apps/macos/Sources/Pomo/Watchfaces/WatchfaceView.swift
@@ -27,54 +27,29 @@ struct FaceControls: View {
     var tint: Color
     var subtle: Bool = false
 
-    @Environment(\.audioControls) private var audio
-
     var body: some View {
-        HStack(spacing: HudSpacing.lg) {
-            // Timer transport — the original reset / play-pause / skip cluster.
-            HStack(spacing: HudSpacing.xl) {
-                Button(action: { model.reset() }) {
-                    Image(systemName: "arrow.counterclockwise")
-                }
-                .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
-                .help("Reset (R)")
-
-                Button(action: { model.toggle() }) {
-                    Image(systemName: model.isRunning ? "pause.fill" : "play.fill")
-                }
-                .buttonStyle(FaceControlStyle(tint: tint, prominent: true, subtle: subtle))
-                .help(model.isRunning ? "Pause (Space)" : "Start (Space)")
-
-                Button(action: { model.skip() }) {
-                    Image(systemName: "forward.end.fill")
-                }
-                .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
-                .help("Skip to next session (N)")
+        // Timer transport — reset / play-pause / skip, centered below the clock.
+        // The audio (music + video) buttons live in the panel's bottom-right
+        // corner instead, so this cluster stays symmetric under the time.
+        HStack(spacing: HudSpacing.xl) {
+            Button(action: { model.reset() }) {
+                Image(systemName: "arrow.counterclockwise")
             }
+            .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
+            .help("Reset (R)")
 
-            // Audio cluster — appears only once a station is set/playing.
-            if audio.enabled {
-                Rectangle()
-                    .fill(tint.opacity(subtle ? 0.18 : 0.3))
-                    .frame(width: 1, height: 16)
-
-                HStack(spacing: HudSpacing.lg) {
-                    Button(action: audio.togglePlay) {
-                        Image(systemName: audio.isPlaying ? "pause.fill" : "music.note")
-                    }
-                    .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
-                    .help(audio.isPlaying ? "Pause music" : "Play music")
-
-                    Button(action: audio.toggleDrawer) {
-                        Image(systemName: audio.drawerOpen ? "rectangle.fill" : "play.rectangle")
-                    }
-                    .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
-                    .help(audio.drawerOpen ? "Hide video" : "Show video")
-                }
-                .transition(.opacity.combined(with: .move(edge: .trailing)))
+            Button(action: { model.toggle() }) {
+                Image(systemName: model.isRunning ? "pause.fill" : "play.fill")
             }
+            .buttonStyle(FaceControlStyle(tint: tint, prominent: true, subtle: subtle))
+            .help(model.isRunning ? "Pause (Space)" : "Start (Space)")
+
+            Button(action: { model.skip() }) {
+                Image(systemName: "forward.end.fill")
+            }
+            .buttonStyle(FaceControlStyle(tint: tint, prominent: false, subtle: subtle))
+            .help("Skip to next session (N)")
         }
-        .animation(.easeOut(duration: 0.2), value: audio.enabled)
     }
 }
 


### PR DESCRIPTION
Iterative design pass on the macOS HUD, plus two reliability fixes that came out of it (login persistence, deterministic CLI targeting).

## HUD / watchfaces
- **Intent replaces the session label.** On the minimal and rolodex faces your intent takes the place of the `FOCUS` label when set (no status dot), instead of crowding in alongside it.
- **Audio buttons docked bottom-right.** Music + video-drawer buttons moved out of the transport row into the panel's bottom-right corner, so reset/play/skip stay centered under the countdown. Sized to match the transport's secondary buttons.
- **Calmer rolodex flip.** Digits settle in one quick, no-bounce snap instead of a springy roll that's always in motion.
- **Minimal face backing.** It was the only watchface without its own background, so over a busy desktop it read as washed-out/see-through. Gave it a clean dark gradient like the others.
- **Opaque quick-entry editor.** The intent/paste card lived inside the translucent panel, so the face + desktop bled through it. The panel now ramps to full opacity while editing, with a solid card and darker scrim — crisp and focused.
- **Hide HUD** added to the HUD right-click menu (with a disabled hint showing the summon hotkey).

## Video menu
- Augment WebKit's native video context menu instead of replacing it: keep the useful items, drop the redundant "Show Controls".
- **Change Track** submenu (your favorites, current one checked).
- Account-aware: signed in → Sign Out; signed out → Sign In + Import (Import is just an alternate sign-in path, so it's hidden when signed in).

## Login persistence
- WKWebView's default store keys cookies by bundle id (dev build vs signed release don't share a login) and drops session cookies between launches. Mirror the auth cookies to `~/Library/Application Support/Pomo/cookies.json` — a path shared by every build — and re-inject on launch. Login now survives relaunches and switching between builds; logout writes through immediately.

## CLI
- With many stale `Pomo.app` bundles registered as `pomo://` handlers (old worktrees, mounted DMGs, cached builds), bare `open pomo://` routed unpredictably to an older copy. `pomo` now targets a specific bundle via `open -a` — `$POMO_APP`, else the dev build beside the CLI in the repo. A plain npm install falls back to default routing.

## Verification
Compiled and verified live throughout via `state.json` + on-screen window captures (the app is built to be agent-inspectable). The `HTTPCookie ⇄ JSON` round-trip was unit-checked in isolation.