### PR TITLE
✨ HUD: Dock presence, keyboard cheat sheet, music + video shortcuts

### DIFF
--- a/apps/macos/Sources/Pomo/AppDelegate.swift
+++ b/apps/macos/Sources/Pomo/AppDelegate.swift
@@ -92,6 +92,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menuBar.onPlayFavorite = { [weak self] favorite in self?.playFavorite(favorite) }
 
         hud.onOpenSettings = { [weak self] in self?.showSettings() }
+        // While the HUD is on screen, run as a regular Dock app so it shows an
+        // icon and is reachable via ⌘-Tab; drop back to a menu-bar accessory
+        // when it's hidden. Also keeps state.json's hudVisible fresh.
+        hud.onVisibilityChange = { [weak self] _ in
+            self?.updateActivationPolicy()
+            self?.writeState()
+        }
 
         // Audio playback state can change asynchronously (web player events),
         // so refresh the state file whenever it does.
@@ -124,6 +131,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         HotkeyManager.shared.register(id: 1, keyCode: keyCode, modifiers: modifiers) { [weak self] in
             self?.hud.toggle()
         }
+    }
+
+    // MARK: - Dock presence
+
+    /// Match the app's activation policy to what's on screen: a regular Dock app
+    /// (so the HUD has an icon and is ⌘-Tab-able) whenever the HUD or an
+    /// auxiliary window is visible, dropping back to a menu-bar accessory when
+    /// nothing is shown. `excluding` skips a window that's mid-close (its
+    /// `isVisible` is still true inside `windowWillClose`).
+    private func updateActivationPolicy(excluding closing: NSWindow? = nil) {
+        func visible(_ window: NSWindow?) -> Bool {
+            guard let window, window !== closing else { return false }
+            return window.isVisible
+        }
+        let wantsDock = hud.isShown || visible(settingsWindow) || visible(statsWindow)
+        NSApp.setActivationPolicy(wantsDock ? .regular : .accessory)
+    }
+
+    /// Clicking the Dock icon (present only while the HUD is up) re-summons the HUD.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        hud.show()
+        return true
     }
 
     // MARK: - Audio helpers
@@ -206,6 +235,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         case .favoritesList:
             break // state (with favorites) is written below
         case .setIntent(let text): model.setIntent(text)
+        case .shortcuts(let visible):
+            hud.show()
+            hud.chrome.showShortcuts = visible ?? !hud.chrome.showShortcuts
         case .openStats:   showStats()
         case .openMenu:    menuBar.toggleMenu()
         case .openSettings: showSettings()
@@ -340,13 +372,8 @@ extension AppDelegate: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         guard let closing = notification.object as? NSWindow,
               closing === settingsWindow || closing === statsWindow else { return }
-        // Back to a menu-bar-only app once our last auxiliary window closes —
-        // but stay regular while the other one is still on screen.
-        let stillOpen = [settingsWindow, statsWindow]
-            .compactMap { $0 }
-            .contains { $0 !== closing && $0.isVisible }
-        if !stillOpen {
-            NSApp.setActivationPolicy(.accessory)
-        }
+        // Re-evaluate Dock presence as this window closes: stay regular while the
+        // HUD or the other auxiliary window is still on screen, else go accessory.
+        updateActivationPolicy(excluding: closing)
     }
 }

--- a/apps/macos/Sources/Pomo/Control/AgentControl.swift
+++ b/apps/macos/Sources/Pomo/Control/AgentControl.swift
@@ -28,6 +28,7 @@ enum PomoCommand {
     case favoriteRemove(Int)    // 1-based
     case favoritesList
     case setIntent(String)      // set the current session's focus intent ("" clears)
+    case shortcuts(Bool?)       // keyboard cheat sheet: nil = toggle, true/false = show/hide
     case openStats
     case openMenu
     case openSettings
@@ -53,6 +54,13 @@ enum PomoCommand {
         case "hide":       self = .hideHUD
         case "toggle-hud", "togglehud", "hud": self = .toggleHUD
         case "menu":       self = .openMenu
+        case "shortcuts", "help", "keys":
+            switch arg {
+            case "show":            self = .shortcuts(true)
+            case "hide":            self = .shortcuts(false)
+            case "toggle", nil:     self = .shortcuts(nil)
+            default:                return nil
+            }
         case "login":
             switch arg {
             case "import":

--- a/apps/macos/Sources/Pomo/HUD/HUDController.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDController.swift
@@ -1,5 +1,14 @@
 import AppKit
+import Observation
 import SwiftUI
+
+/// HUD-only presentation chrome the SwiftUI content reacts to but the AppKit key
+/// monitor drives — currently just the keyboard cheat sheet toggled with `?`.
+@MainActor
+@Observable
+final class HUDChrome {
+    var showShortcuts = false
+}
 
 /// Owns the floating HUD panel: lazy construction, summon/dismiss with a fade,
 /// first-summon positioning (respecting later drags), and the in-panel keyboard
@@ -13,6 +22,14 @@ final class HUDController {
 
     /// Opens the settings window (⌘,). Wired by AppDelegate.
     var onOpenSettings: (() -> Void)?
+
+    /// Fired after the HUD is summoned/dismissed so the app can match its Dock
+    /// presence to HUD visibility (a regular Dock app while shown — so it's
+    /// ⌘-Tab-able — dropping back to a menu-bar accessory when hidden).
+    var onVisibilityChange: ((Bool) -> Void)?
+
+    /// HUD-only chrome (keyboard cheat sheet) shared with the SwiftUI content.
+    let chrome = HUDChrome()
 
     private let contentSize = NSSize(width: 352, height: 268)
     private var panel: HUDPanel?
@@ -35,6 +52,7 @@ final class HUDController {
         let hosting = NSHostingView(
             rootView: HUDRootView(
                 model: model, settings: settings, audio: audio, favorites: favorites,
+                chrome: chrome,
                 size: contentSize,
                 onHide: { [weak self] in self?.hide() },
                 onEditingChange: { [weak self] editing in self?.setEditingFocus(editing) }
@@ -72,15 +90,18 @@ final class HUDController {
         }
         // Dock the video drawer to the panel (slides back out if it was open).
         audio.attachDrawer(to: panel)
+        onVisibilityChange?(true)
     }
 
     func hide() {
         guard let panel, isShown else { return }
         isShown = false
-        // Don't leave a quick field armed for the next summon.
+        // Don't leave a quick field armed — or the cheat sheet up — for next summon.
         model.cancelEditing()
+        chrome.showShortcuts = false
         removeKeyMonitor()
         audio.detachDrawer()
+        onVisibilityChange?(false)
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.14
             ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
@@ -146,6 +167,12 @@ final class HUDController {
             return false
         }
 
+        // While the cheat sheet is up, Escape closes the sheet (not the whole HUD).
+        if chrome.showShortcuts, event.keyCode == 53 {
+            chrome.showShortcuts = false
+            return true
+        }
+
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let command = flags.contains(.command)
         let shift = flags.contains(.shift)
@@ -179,7 +206,12 @@ final class HUDController {
         case "n": model.skip(); return true
         case "c": model.cycleSessionType(); return true
         case "i": model.beginEditing(.intent); return true
-        case "v": model.beginEditing(.video); return true
+        case "v":
+            if shift { toggleVideoDrawer() }            // ⇧V: show / hide the video drawer
+            else { model.beginEditing(.video) }         // v: paste an audio / video link
+            return true
+        case "m": toggleMusic(); return true            // play/pause background music
+        case "?", "/": chrome.showShortcuts.toggle(); return true  // keyboard cheat sheet
         case "q": hide(); return true
         case "t":
             settings.watchface = settings.watchface.next
@@ -194,5 +226,29 @@ final class HUDController {
         default:
             return false
         }
+    }
+
+    // MARK: - Music
+
+    private func toggleMusic() {
+        if audio.isPlaying { audio.pause() }
+        else { audio.resume(stored: preferredAudioURL()) }
+    }
+
+    /// Show / hide the docked video drawer. Mirrors the on-face button: if nothing
+    /// is loaded yet, kick off the saved station so the drawer has something to show.
+    private func toggleVideoDrawer() {
+        if !audio.videoOpen, !audio.isPlaying, audio.currentURL.isEmpty, !settings.audioURL.isEmpty {
+            audio.play(urlString: settings.audioURL)
+        }
+        audio.toggleVideo()
+    }
+
+    /// Best URL to (re)start when toggling music from the HUD: whatever's already
+    /// loaded, then the saved station, then the first favorite.
+    private func preferredAudioURL() -> String {
+        if !audio.currentURL.isEmpty { return audio.currentURL }
+        if !settings.audioURL.isEmpty { return settings.audioURL }
+        return favorites.items.first?.url ?? ""
     }
 }

--- a/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/Pomo/HUD/HUDRootView.swift
@@ -11,6 +11,8 @@ struct HUDRootView: View {
     let settings: PomoSettings
     let audio: AudioController
     let favorites: FavoritesStore
+    /// Shared HUD chrome (keyboard cheat sheet), driven by HUDController's key monitor.
+    let chrome: HUDChrome
     let size: CGSize
     /// Dismiss the HUD (right-click → Hide). Wired by HUDController.
     var onHide: (() -> Void)? = nil
@@ -96,7 +98,15 @@ struct HUDRootView: View {
             if audioFaceControls.enabled, model.quickField == .none {
                 audioCornerControls
             }
+
+            // Keyboard cheat sheet, toggled with `?` (or the right-click menu).
+            // Sits above everything; tap / `?` / Esc to dismiss.
+            if chrome.showShortcuts {
+                ShortcutsOverlay(onClose: { chrome.showShortcuts = false })
+                    .transition(.opacity)
+            }
         }
+        .animation(.easeOut(duration: 0.12), value: chrome.showShortcuts)
         .frame(width: size.width, height: size.height)
         .clipShape(panelShape)
         .overlay(
@@ -184,10 +194,99 @@ struct HUDRootView: View {
 
         Divider()
 
+        Button("Keyboard Shortcuts") { chrome.showShortcuts = true }
+
+        Divider()
+
         Button("Hide HUD") { onHide?() }
         // You can't right-click a hidden HUD, so remind them how to bring it back.
         Button("Reopen with \(settings.hotkeyDisplay)") {}
             .disabled(true)
+    }
+}
+
+/// A translucent reference card of the HUD's keyboard shortcuts. Toggled with
+/// `?` (or the right-click menu); dismissed with `?` again, Escape, or a tap.
+/// Two compact columns so it fits the panel without scrolling.
+private struct ShortcutsOverlay: View {
+    var onClose: () -> Void
+
+    private let left: [(String, String)] = [
+        ("Space", "Start / Pause"),
+        ("S", "Start"),
+        ("P", "Pause"),
+        ("R", "Reset"),
+        ("N", "Skip session"),
+        ("C", "Cycle type"),
+        ("T", "Next face"),
+        ("↑ ↓", "±1 min · ⇧5"),
+    ]
+    private let right: [(String, String)] = [
+        ("1–9", "Set 5–45 min"),
+        ("I", "Set intent"),
+        ("V", "Paste link"),
+        ("⇧V", "Show/hide video"),
+        ("M", "Music play/pause"),
+        ("⌘ ,", "Settings"),
+        ("Esc Q", "Hide HUD"),
+        ("?", "Close help"),
+    ]
+
+    var body: some View {
+        ZStack {
+            // Tap anywhere to dismiss.
+            Rectangle()
+                .fill(Color.black.opacity(0.86))
+                .contentShape(Rectangle())
+                .onTapGesture(perform: onClose)
+
+            VStack(alignment: .leading, spacing: HudSpacing.md) {
+                HStack {
+                    Text("KEYBOARD")
+                        .font(HudFont.mono(HudTextSize.micro, weight: .bold))
+                        .tracking(1.5)
+                        .foregroundStyle(HudPalette.dim)
+                    Spacer(minLength: HudSpacing.sm)
+                    Text("? or esc to close")
+                        .font(HudFont.mono(HudTextSize.micro))
+                        .foregroundStyle(HudPalette.dim.opacity(0.7))
+                }
+
+                HStack(alignment: .top, spacing: HudSpacing.lg) {
+                    column(left)
+                    column(right)
+                }
+            }
+            .padding(HudSpacing.xl)
+        }
+    }
+
+    private func column(_ rows: [(String, String)]) -> some View {
+        VStack(alignment: .leading, spacing: HudSpacing.xs) {
+            ForEach(rows.indices, id: \.self) { i in
+                HStack(spacing: HudSpacing.sm) {
+                    keyCap(rows[i].0)
+                    Text(rows[i].1)
+                        .font(HudFont.mono(HudTextSize.xxs))
+                        .foregroundStyle(HudPalette.muted)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func keyCap(_ key: String) -> some View {
+        Text(key)
+            .font(HudFont.mono(HudTextSize.xxs, weight: .semibold))
+            .foregroundStyle(HudPalette.ink)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .frame(minWidth: 40)
+            .background(RoundedRectangle(cornerRadius: HudRadius.tight, style: .continuous).fill(Color.white.opacity(0.08)))
+            .overlay(RoundedRectangle(cornerRadius: HudRadius.tight, style: .continuous).stroke(HudPalette.border, lineWidth: 1))
     }
 }
 


### PR DESCRIPTION
Makes the floating HUD switchable and more keyboard-driven.

## Changes
- **Dock presence** — while the HUD is on screen the app runs as a regular Dock app (icon + ⌘-Tab), dropping back to a menu-bar accessory when hidden. Clicking the Dock icon re-summons the HUD.
- **Keyboard cheat sheet** — press <kbd>?</kbd> (or the right-click menu → Keyboard Shortcuts) for a two-column overlay of every HUD shortcut; dismiss with <kbd>?</kbd>, <kbd>Esc</kbd>, or a tap.
- **<kbd>m</kbd>** toggles background music play/pause from the HUD.
- **<kbd>⇧V</kbd>** shows/hides the docked video drawer (<kbd>v</kbd> still pastes a link).
- **`pomo://shortcuts[/show|hide|toggle]`** (aliases `help`, `keys`) toggles the cheat sheet, keeping the HUD agent-inspectable.

## Verification
- `swift build` clean on this branch (based directly on `main`).
- Verified live: Dock presence flips `Foreground` ⇄ `UIElement` on show/hide; cheat-sheet overlay renders; `pomo://video/toggle` (same call as ⇧V) opens the drawer.

Scoped to the HUD only — `HUDController`, `HUDRootView`, and the HUD wiring in `AppDelegate`/`AgentControl`. Independent of the login/audio-video work in #23.