### PR TITLE
🔖 Release: @arach/pomo 0.2.0 + macOS v0.2.6

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arach/pomo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Control and install the Pomo macOS HUD timer from the shell or an agent — a thin wrapper over the pomo:// URL scheme and the JSON state file.",
   "type": "module",
   "bin": {

--- a/apps/tauri/landing/app/home-content.tsx
+++ b/apps/tauri/landing/app/home-content.tsx
@@ -144,7 +144,7 @@ function Nav() {
           <a href="#stats" style={link}><span style={{ color: "#6b6055" }}>:</span>stats</a>
         </nav>
         <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
-          <span style={{ fontFamily: mono, fontSize: 11, color: "#6b6055", letterSpacing: "0.06em" }}>v0.2.4 · macOS</span>
+          <span style={{ fontFamily: mono, fontSize: 11, color: "#6b6055", letterSpacing: "0.06em" }}>v0.2.6 · macOS</span>
           <a
             href={DOWNLOAD_URL}
             style={{
@@ -903,7 +903,7 @@ function DownloadCTA() {
             >
               View source
             </a>
-            <span style={{ fontFamily: mono, fontSize: 11, letterSpacing: "0.06em", color: "#6b6055" }}>v0.2.4 · macOS 13+</span>
+            <span style={{ fontFamily: mono, fontSize: 11, letterSpacing: "0.06em", color: "#6b6055" }}>v0.2.6 · macOS 13+</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Version bumps to cut two releases. Both ship via tag-driven Actions after this merges; the tags are pushed afterward (`cli-v0.2.0`, `v0.2.6`).

## @arach/pomo `0.1.0` → `0.2.0` (npm)
Minor bump — the CLI has gained new commands since the inaugural `cli-v0.1.0` publish:
- `audio session <focus|break|long> <fav#|url|clear>` + a session-audio block in `pomo status`
- favorites management: `fav rename`, `fav url`, `fav move`, `fav set <json>`, `fav clear`
- `video page|player` aliases
- dev-app targeting so `pomo://` hits the sibling repo build, not a stale registered bundle

## macOS app `v0.2.5` → `v0.2.6`
Patch bump for the app. Landing badge updated `v0.2.4` → `v0.2.6` (it was a release behind). The signed + notarized DMG release is cut by `release-app-macos.yml` when the `v0.2.6` tag is pushed.