### PR TITLE
[codex] Fix Pomo Amp menubar and login import

### DIFF
--- a/.github/workflows/release-app-macos.yml
+++ b/.github/workflows/release-app-macos.yml
@@ -179,6 +179,17 @@ jobs:
           set -euo pipefail
 
           hdiutil verify apps/macos/dist/Pomo.dmg
+          mount_point="$(mktemp -d)"
+          hdiutil attach apps/macos/dist/Pomo.dmg -nobrowse -readonly -mountpoint "$mount_point"
+          cleanup() {
+            hdiutil detach "$mount_point" >/dev/null 2>&1 || true
+            rm -rf "$mount_point"
+          }
+          trap cleanup EXIT
+          test -d "$mount_point/Pomo.app"
+          test -L "$mount_point/Applications"
+          test ! -e "$mount_point/Pomo Amp.app"
+          test -d "$mount_point/Pomo.app/Contents/Helpers/Pomo Amp.app"
           if [[ "$SHOULD_PUBLISH" == "1" ]]; then
             codesign --verify --verbose apps/macos/dist/Pomo.dmg
             spctl --assess --type open --context context:primary-signature --verbose apps/macos/dist/Pomo.dmg
@@ -209,7 +220,7 @@ jobs:
           cat > "$notes_path" <<EOF
           Release $VERSION
 
-          Download and install Pomo and Pomo Amp for Mac.
+          Download Pomo for Mac. Pomo Amp ships inside Pomo.app as the music companion.
           EOF
 
           if gh release view "$release_tag" >/dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ implementation today), native **iOS** and **watchOS** apps, and the original
 
 Menu-bar HUD timer: a hotkey-summoned frosted panel, swappable **watchfaces**
 (including the engineering-drawing **Blueprint** face), tunable **backdrop blur**,
-background audio, and a `pomo://` URL scheme for agent control. The same package
-also builds **Pomo Amp**, a small YouTube music-player sibling with custom HTML
-skins.
+background audio, and a `pomo://` URL scheme for agent control. The macOS app
+ships with **Pomo Amp** nested inside it: a small YouTube music-player companion
+with its own menu-bar lifecycle and custom HTML skins.
 
 ```sh
 cd apps/macos
@@ -27,7 +27,7 @@ scripts/run-app.sh            # build dist/Pomo.app and launch
 scripts/run-app.sh --no-open  # build only
 scripts/run-app.sh --debug    # faster local build
 scripts/run-app.sh --amp --debug  # build and launch Pomo Amp
-scripts/build-dmg.sh --local  # build a local smoke-test DMG with Pomo + Pomo Amp
+scripts/build-dmg.sh --local  # build a one-app DMG with nested Pomo Amp
 ```
 
 No private checkout needed — HudsonKit is consumed as a public, prebuilt **binary**

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -42,7 +42,7 @@ scripts/run-app.sh --restart        # quit a running copy before launching
 scripts/run-app.sh --no-open        # build dist/Pomo.app without launching
 scripts/run-app.sh --amp --debug    # build and launch the Pomo Amp music-player app
 scripts/run-app.sh --no-open --sign -  # local ad-hoc signature
-scripts/build-dmg.sh --local        # build a local smoke-test DMG with Pomo + Pomo Amp
+scripts/build-dmg.sh --local        # build a one-app DMG with nested Pomo Amp
 open dist/Pomo.app                  # launch the built app later
 ```
 
@@ -96,16 +96,17 @@ codesign --verify --deep --strict --verbose=2 dist/Pomo.app
 open dist/Pomo.app
 ```
 
-To package Pomo and Pomo Amp as peer apps in a drag-to-Applications DMG for local testing:
+To package one visible `Pomo.app` in a drag-to-Applications DMG for local testing:
 
 ```sh
 scripts/build-dmg.sh --local
 open dist/Pomo.dmg
 ```
 
-That DMG contains `Pomo.app`, `Pomo Amp.app`, and an Applications shortcut. It is
-convenient for local testing, but it is still not a publicly trusted download
-unless you sign and notarize it.
+That DMG contains `Pomo.app` and an Applications shortcut. `Pomo Amp.app` is
+embedded inside `Pomo.app/Contents/Helpers/` so users install one app while Amp
+keeps its own process and menu-bar lifecycle. It is convenient for local testing,
+but it is still not a publicly trusted download unless you sign and notarize it.
 
 For a build you plan to share, use an Apple Developer ID Application certificate
 and notarize the DMG. Replace the identity and notary profile names with your own:
@@ -157,7 +158,8 @@ Pomo-<version>.dmg
 ```
 
 Both assets are the same notarized product DMG. The mounted volume contains
-`Pomo.app`, `Pomo Amp.app`, and an Applications shortcut.
+`Pomo.app` and an Applications shortcut; `Pomo Amp.app` is nested at
+`Pomo.app/Contents/Helpers/Pomo Amp.app`.
 
 The landing page downloads from:
 
@@ -229,13 +231,15 @@ clean clone builds standalone. The first build downloads the release XCFramework
 
 ## Pomo Amp
 
-`Pomo Amp` is a sibling macOS product built from the same shared native code and
-shipped in the same DMG as `Pomo.app`. It uses the YouTube/audio engine and
-timestamp navigation as a compact music player, with `⌃⌥⇧⌘Y` as its default
-summon hotkey on a fresh profile. Drag the top strip to move it, press `B` or the
-top-right big button to switch sizes, and use the small Pomo icon to show or hide
-Pomo from Amp. When Pomo Amp is already running, Pomo defers video show/hide
-commands to Amp while keeping Pomo's timer lifecycle independent.
+`Pomo Amp` is a companion macOS product built from the same shared native code.
+Release DMGs ship it nested inside `Pomo.app`, while local development can still
+build and run it directly with `scripts/run-app.sh --amp`. It uses the
+YouTube/audio engine and timestamp navigation as a compact music player, with
+`⌃⌥⇧⌘Y` as its default summon hotkey on a fresh profile. Drag the top strip to
+move it, press `B` or the top-right big button to switch sizes, and use the small
+Pomo icon to show or hide Pomo from Amp. Pomo can launch or quit Amp from its
+menu, and when Pomo Amp is already running, Pomo defers video show/hide commands
+to Amp while keeping Pomo's timer lifecycle independent.
 
 ```sh
 cd apps/macos

--- a/apps/macos/Sources/PomoShared/AppDelegate.swift
+++ b/apps/macos/Sources/PomoShared/AppDelegate.swift
@@ -95,6 +95,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         menuBar.onToggleAudio = { [weak self] in self?.toggleAudio() }
         menuBar.onStopAudio = { [weak self] in self?.audio.stop() }
         menuBar.onPlayFavorite = { [weak self] favorite in self?.playFavorite(favorite) }
+        menuBar.onOpenPomoAmp = { [weak self] in self?.openPomoAmp() }
+        menuBar.onQuitPomoAmp = { [weak self] in self?.quitPomoAmp() }
+        menuBar.isPomoAmpRunning = { [weak self] in self?.runningPomoAmpApplication() != nil }
+        menuBar.hasPomoAmpCompanion = { [weak self] in
+            guard let self else { return false }
+            return self.runningPomoAmpApplication() != nil || self.availablePomoAmpAppURL() != nil
+        }
 
         hud.onOpenSettings = { [weak self] in self?.showSettings() }
         hud.onVideoCommand = { [weak self] command in
@@ -242,7 +249,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             settings.setAudioURL(url, for: type)
             menuBar.refresh()
         case .login:       audio.signIn()
-        case .importCookies(let browser, let profile): audio.importCookies(browser: browser, profile: profile)
+        case .importCookies(let browser, let profile, let accountIndex):
+            audio.importCookies(browser: browser, profile: profile, accountIndex: accountIndex)
         case .logout: audio.clearLogin()
         case .selectAccount(let index): audio.setAccount(index)
         case .videoShow:
@@ -290,11 +298,29 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         writeState()
     }
 
+    private func openPomoAmp() {
+        _ = sendPomoAmpCommand(.showHUD, launchIfNeeded: true)
+    }
+
+    private func quitPomoAmp() {
+        _ = sendPomoAmpCommand(.quit, launchIfNeeded: false)
+    }
+
     private func deferVideoCommandToPomoAmp(_ command: PomoCommand) -> Bool {
-        guard let url = pomoAmpURL(for: command),
-              let app = runningPomoAmpApplication(),
-              let bundleURL = app.bundleURL
-        else { return false }
+        sendPomoAmpCommand(command, launchIfNeeded: false)
+    }
+
+    private func sendPomoAmpCommand(_ command: PomoCommand, launchIfNeeded: Bool) -> Bool {
+        guard let url = pomoAmpURL(for: command) else { return false }
+        let bundleURL: URL?
+        if let app = runningPomoAmpApplication(), let runningBundleURL = app.bundleURL {
+            bundleURL = runningBundleURL
+        } else if launchIfNeeded {
+            bundleURL = availablePomoAmpAppURL()
+        } else {
+            bundleURL = nil
+        }
+        guard let bundleURL else { return false }
 
         let configuration = NSWorkspace.OpenConfiguration()
         NSWorkspace.shared.open([url], withApplicationAt: bundleURL, configuration: configuration) { _, error in
@@ -307,13 +333,28 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func pomoAmpURL(for command: PomoCommand) -> URL? {
         switch command {
+        case .showHUD:     return URL(string: "pomo-amp://show")
+        case .hideHUD:     return URL(string: "pomo-amp://hide")
+        case .toggleHUD:   return URL(string: "pomo-amp://toggle-hud")
         case .videoShow:   return URL(string: "pomo-amp://video/show")
         case .videoHide:   return URL(string: "pomo-amp://video/hide")
         case .videoToggle: return URL(string: "pomo-amp://video/toggle")
         case .videoPage:   return URL(string: "pomo-amp://video/page")
         case .videoPlayer: return URL(string: "pomo-amp://video/player")
+        case .quit:        return URL(string: "pomo-amp://quit")
         default:           return nil
         }
+    }
+
+    private func availablePomoAmpAppURL() -> URL? {
+        let bundleURL = Bundle.main.bundleURL
+        let candidates = [
+            bundleURL.appendingPathComponent("Contents/Helpers/Pomo Amp.app", isDirectory: true),
+            bundleURL.deletingLastPathComponent().appendingPathComponent("Pomo Amp.app", isDirectory: true),
+        ]
+        return candidates.first(where: { url in
+            FileManager.default.fileExists(atPath: url.appendingPathComponent("Contents/Info.plist").path)
+        })
     }
 
     private func runningPomoAmpApplication() -> NSRunningApplication? {

--- a/apps/macos/Sources/PomoShared/Audio/AudioController.swift
+++ b/apps/macos/Sources/PomoShared/Audio/AudioController.swift
@@ -65,7 +65,9 @@ final class AudioController {
     func persistPlaybackSnapshot() { web.persistPlaybackSnapshotNow() }
     func signIn() { web.signIn() }
     func showImportLogin() { web.showImportLogin() }
-    func importCookies(browser: String?, profile: String?) { web.importCookies(fromBrowser: browser, profile: profile) }
+    func importCookies(browser: String?, profile: String?, accountIndex: Int = 0) {
+        web.importCookies(fromBrowser: browser, profile: profile, accountIndex: accountIndex)
+    }
     func clearLogin() { web.clearLogin() }
     func setAccount(_ index: Int) { web.setAccount(index) }
     func requestAudioScopePermission() { web.requestAudioScopePermission(); notify() }

--- a/apps/macos/Sources/PomoShared/Audio/CookieImporter.swift
+++ b/apps/macos/Sources/PomoShared/Audio/CookieImporter.swift
@@ -101,7 +101,17 @@ enum CookieImporter {
     private static func parse(_ text: String) -> [HTTPCookie] {
         var cookies: [HTTPCookie] = []
         for rawLine in text.split(separator: "\n") {
-            let fields = String(rawLine).components(separatedBy: "\t")
+            var line = String(rawLine)
+            guard !line.isEmpty else { continue }
+            var httpOnly = false
+            if line.hasPrefix("#HttpOnly_") {
+                httpOnly = true
+                line.removeFirst("#HttpOnly_".count)
+            } else if line.hasPrefix("#") {
+                continue
+            }
+
+            let fields = line.components(separatedBy: "\t")
             guard fields.count >= 7 else { continue }
             let domain = fields[0]
             let path = fields[2].isEmpty ? "/" : fields[2]
@@ -115,6 +125,7 @@ enum CookieImporter {
                 .domain: domain, .path: path, .name: name, .value: value,
             ]
             if secure { props[.secure] = "TRUE" }
+            if httpOnly { props[HTTPCookiePropertyKey("HttpOnly")] = "TRUE" }
             if let expiry, expiry > 0 { props[.expires] = Date(timeIntervalSince1970: expiry) }
             if let cookie = HTTPCookie(properties: props) { cookies.append(cookie) }
         }

--- a/apps/macos/Sources/PomoShared/Audio/CoreAudioTapAudioScope.swift
+++ b/apps/macos/Sources/PomoShared/Audio/CoreAudioTapAudioScope.swift
@@ -86,7 +86,7 @@ final class CoreAudioTapAudioScope {
     }
 
     func setFrameInterval(milliseconds: Int) {
-        let interval = Double(max(50, min(500, milliseconds))) / 1000.0
+        let interval = Double(max(33, min(500, milliseconds))) / 1000.0
         sampleQueue.async { [weak self] in
             guard let self else { return }
             guard abs(self.frameInterval - interval) > 0.001 else { return }

--- a/apps/macos/Sources/PomoShared/Audio/LoginPersistence.swift
+++ b/apps/macos/Sources/PomoShared/Audio/LoginPersistence.swift
@@ -28,14 +28,16 @@ enum CookieJar {
         let path: String
         let expires: Double?   // seconds since 1970; nil = session cookie
         let secure: Bool
+        let httpOnly: Bool
     }
 
     /// Persist the given cookies (caller filters to the auth domains). Written
     /// owner-only since these are login credentials.
     static func save(_ cookies: [HTTPCookie]) {
-        let stored = cookies.map {
+        let stored = cookies.filter { isAllowedDomain($0.domain) }.map {
             Stored(name: $0.name, value: $0.value, domain: $0.domain, path: $0.path,
-                   expires: $0.expiresDate?.timeIntervalSince1970, secure: $0.isSecure)
+                   expires: $0.expiresDate?.timeIntervalSince1970, secure: $0.isSecure,
+                   httpOnly: $0.isHTTPOnly)
         }
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted]
@@ -57,8 +59,17 @@ enum CookieJar {
             ]
             if let e = s.expires { props[.expires] = Date(timeIntervalSince1970: e) }
             if s.secure { props[.secure] = "TRUE" }
+            if s.httpOnly { props[HTTPCookiePropertyKey("HttpOnly")] = "TRUE" }
             return HTTPCookie(properties: props)
         }
+    }
+
+    private static func isAllowedDomain(_ domain: String) -> Bool {
+        let d = domain
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        return d == "youtube.com" || d.hasSuffix(".youtube.com")
+            || d == "google.com" || d.hasSuffix(".google.com")
     }
 }
 

--- a/apps/macos/Sources/PomoShared/Audio/ScreenCaptureAudioPermission.swift
+++ b/apps/macos/Sources/PomoShared/Audio/ScreenCaptureAudioPermission.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import CoreServices
 import CoreGraphics
 import Foundation
 import SwiftUI
@@ -7,8 +8,36 @@ import SwiftUI
 enum ScreenCaptureAudioPermission {
     static let neededMessage = "audio scope needs macOS screen/system audio permission"
     static let requirementLabel = "Screen & System Audio Recording"
+    static let tccService = "AudioCapture"
+    static let legacyTCCService = "ScreenCapture"
     private static let successfulAccessUntilKey = "pomo.visualizerAudio.successfulAccessUntil"
     private static let successfulAccessTTL: TimeInterval = 60 * 60
+
+    struct PermissionTarget: Equatable {
+        let appURL: URL
+        let bundleIdentifier: String
+        let displayName: String
+        let isAppBundle: Bool
+
+        var path: String { appURL.path }
+    }
+
+    static var permissionTarget: PermissionTarget {
+        let appURL = appBundleURL(for: Bundle.main.bundleURL)
+        let bundle = Bundle(url: appURL) ?? Bundle.main
+        let bundleIdentifier = bundle.bundleIdentifier
+            ?? Bundle.main.bundleIdentifier
+            ?? ""
+        let displayName = (bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String)
+            ?? (bundle.object(forInfoDictionaryKey: "CFBundleName") as? String)
+            ?? appURL.deletingPathExtension().lastPathComponent
+        return PermissionTarget(
+            appURL: appURL,
+            bundleIdentifier: bundleIdentifier,
+            displayName: displayName,
+            isAppBundle: appBundleExists(at: appURL)
+        )
+    }
 
     static var systemReportsAccess: Bool {
         CGPreflightScreenCaptureAccess()
@@ -44,13 +73,53 @@ enum ScreenCaptureAudioPermission {
 
     @MainActor
     static func showAssistant(startRequest: Bool = false) {
+        registerPermissionTarget(reason: "show assistant")
         ScreenCaptureAudioPermissionWindowController.shared.show(startRequest: startRequest)
     }
 
     static func openSettings() {
+        registerPermissionTarget(reason: "open settings")
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
             NSWorkspace.shared.open(url)
         }
+    }
+
+    @discardableResult
+    static func registerPermissionTarget(reason: String) -> Bool {
+        let target = permissionTarget
+        guard target.isAppBundle else {
+            print("[pomo-permissions] permission target is not an app bundle: \(target.path)")
+            return false
+        }
+
+        let status = LSRegisterURL(target.appURL as CFURL, true)
+        if status == noErr {
+            print("[pomo-permissions] registered \(target.bundleIdentifier) at \(target.path) (\(reason))")
+            return true
+        }
+
+        print("[pomo-permissions] LSRegisterURL failed status=\(status) path=\(target.path)")
+        return false
+    }
+
+    private static func appBundleURL(for url: URL) -> URL {
+        var candidate = url.standardizedFileURL
+        if appBundleExists(at: candidate) {
+            return candidate
+        }
+
+        while candidate.path != "/" {
+            if candidate.pathExtension == "app", appBundleExists(at: candidate) {
+                return candidate
+            }
+            candidate.deleteLastPathComponent()
+        }
+
+        return url.standardizedFileURL
+    }
+
+    private static func appBundleExists(at url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.appendingPathComponent("Contents/Info.plist").path)
     }
 }
 
@@ -95,11 +164,13 @@ final class ScreenCaptureAudioPermissionChecker: ObservableObject {
 
         if !hasLoggedIdentity {
             hasLoggedIdentity = true
+            let target = ScreenCaptureAudioPermission.permissionTarget
             let bundleId = Bundle.main.bundleIdentifier ?? "<no bundle id>"
             let execPath = Bundle.main.executablePath ?? ProcessInfo.processInfo.arguments.first ?? "<unknown>"
             let pid = ProcessInfo.processInfo.processIdentifier
             print("[pomo-permissions] bundleId=\(bundleId) pid=\(pid)")
             print("[pomo-permissions] exec=\(execPath)")
+            print("[pomo-permissions] permissionTarget bundleId=\(target.bundleIdentifier) path=\(target.path)")
             print("[pomo-permissions] CGPreflightScreenCaptureAccess() -> \(preflight)")
         }
 
@@ -111,21 +182,14 @@ final class ScreenCaptureAudioPermissionChecker: ObservableObject {
     }
 
     func requestScreenAudio() {
+        ScreenCaptureAudioPermission.registerPermissionTarget(reason: "request permission")
         check()
         guard !screenAudio else { return }
 
         refreshInFlight = true
-        lastMessage = "Opening macOS permission flow..."
+        let target = ScreenCaptureAudioPermission.permissionTarget
+        lastMessage = "Opening Settings for \(target.displayName)..."
         NSApp.activate(ignoringOtherApps: true)
-
-        let requestResult = CGRequestScreenCaptureAccess()
-        print("[pomo-permissions] CGRequestScreenCaptureAccess() -> \(requestResult)")
-        if requestResult {
-            screenAudio = true
-            refreshInFlight = false
-            lastMessage = "\(ScreenCaptureAudioPermission.requirementLabel) is enabled."
-            return
-        }
 
         finishRequestAfterPermissionRequest()
     }
@@ -149,21 +213,27 @@ final class ScreenCaptureAudioPermissionChecker: ObservableObject {
     }
 
     func resetSavedApproval() {
-        let bundleId = Bundle.main.bundleIdentifier ?? ""
+        let target = ScreenCaptureAudioPermission.permissionTarget
+        ScreenCaptureAudioPermission.registerPermissionTarget(reason: "reset saved approval")
+        let bundleId = target.bundleIdentifier
         guard !bundleId.isEmpty else { return }
         refreshInFlight = true
         screenAudio = false
         lastMessage = "Clearing saved macOS permission row..."
 
         DispatchQueue.global(qos: .userInitiated).async {
-            let result = Self.runTccutilReset(service: "ScreenCapture", bundleId: bundleId)
+            let result = Self.runTccutilReset(service: ScreenCaptureAudioPermission.tccService, bundleId: bundleId)
+            let legacyResult = Self.runTccutilReset(service: ScreenCaptureAudioPermission.legacyTCCService, bundleId: bundleId)
             DispatchQueue.main.async {
                 if result.status == 0 {
-                    print("[pomo-permissions] tccutil reset ScreenCapture \(bundleId)")
-                    self.lastMessage = "Cleared saved row. Add the current Pomo Amp app again."
+                    print("[pomo-permissions] tccutil reset \(ScreenCaptureAudioPermission.tccService) \(bundleId)")
+                    if legacyResult.status == 0 {
+                        print("[pomo-permissions] tccutil reset \(ScreenCaptureAudioPermission.legacyTCCService) \(bundleId)")
+                    }
+                    self.lastMessage = "Cleared saved row. Add \(target.displayName) again."
                 } else {
                     let detail = result.output.isEmpty ? "exit \(result.status)" : result.output
-                    print("[pomo-permissions] tccutil reset ScreenCapture failed: \(detail)")
+                    print("[pomo-permissions] tccutil reset \(ScreenCaptureAudioPermission.tccService) failed: \(detail)")
                     self.lastMessage = "Could not clear the saved row: \(detail)"
                 }
                 self.openSettings()
@@ -173,7 +243,7 @@ final class ScreenCaptureAudioPermissionChecker: ObservableObject {
     }
 
     func quitAndRelaunch() {
-        let appURL = Bundle.main.bundleURL
+        let appURL = ScreenCaptureAudioPermission.permissionTarget.appURL
         let task = Process()
         task.launchPath = "/bin/sh"
         task.arguments = [
@@ -216,7 +286,8 @@ final class ScreenCaptureAudioPermissionChecker: ObservableObject {
             lastMessage = "\(ScreenCaptureAudioPermission.requirementLabel) is enabled."
             stopPolling()
         } else {
-            lastMessage = "Open System Settings, add Pomo Amp if needed, and toggle it on."
+            let target = ScreenCaptureAudioPermission.permissionTarget
+            lastMessage = "Open System Settings, add \(target.displayName) if needed, and toggle it on."
             openSettings()
             startPolling()
             schedulePermissionRefresh()
@@ -460,13 +531,15 @@ private struct ScreenCaptureAudioPermissionAssistantView: View {
 
     private var dragCard: some View {
         sectionCard(title: "IF SETTINGS SHOWS AN OLD ENTRY") {
+            let target = ScreenCaptureAudioPermission.permissionTarget
             HStack(alignment: .center, spacing: 14) {
                 PomoAmpPermissionAppDragTile(
-                    appURL: Bundle.main.bundleURL,
-                    appIcon: NSWorkspace.shared.icon(forFile: Bundle.main.bundleURL.path),
+                    appURL: target.appURL,
+                    appIcon: NSWorkspace.shared.icon(forFile: target.path),
                     permissionName: ScreenCaptureAudioPermission.requirementLabel,
                     isDragEnabled: !checker.granted,
                     onDragStarted: {
+                        ScreenCaptureAudioPermission.registerPermissionTarget(reason: "drag started")
                         checker.passiveRecheck(reason: "drag started")
                     },
                     onDragCompleted: {
@@ -476,13 +549,13 @@ private struct ScreenCaptureAudioPermissionAssistantView: View {
                 .frame(width: 92, height: 92)
 
                 VStack(alignment: .leading, spacing: 5) {
-                    Text(checker.granted ? "Current Pomo Amp app is enabled" : "Optional: add the current Pomo Amp app")
+                    Text(checker.granted ? "\(target.displayName) is enabled" : "Add the running \(target.displayName) app")
                         .font(.system(size: 12, weight: .black, design: .monospaced))
-                    Text("If macOS shows an older Pomo Amp row, remove it first. Then drag this app into Screen & System Audio Recording and toggle it on.")
+                    Text("If macOS shows an older row, remove it first. Then drag this exact app into Screen & System Audio Recording and toggle it on.")
                         .font(.system(size: 10, weight: .medium))
                         .foregroundStyle(Color.white.opacity(0.58))
                         .lineSpacing(2)
-                    Text(Bundle.main.bundleURL.path)
+                    Text(target.bundleIdentifier.isEmpty ? target.path : "\(target.bundleIdentifier)  \(target.path)")
                         .font(.system(size: 8.5, weight: .medium, design: .monospaced))
                         .foregroundStyle(Color.white.opacity(0.42))
                         .lineLimit(2)
@@ -511,7 +584,8 @@ private struct ScreenCaptureAudioPermissionAssistantView: View {
             }
 
             Button {
-                NSWorkspace.shared.activateFileViewerSelecting([Bundle.main.bundleURL])
+                ScreenCaptureAudioPermission.registerPermissionTarget(reason: "reveal app")
+                NSWorkspace.shared.activateFileViewerSelecting([ScreenCaptureAudioPermission.permissionTarget.appURL])
             } label: {
                 Label("Reveal App", systemImage: "folder")
             }
@@ -529,7 +603,7 @@ private struct ScreenCaptureAudioPermissionAssistantView: View {
                 } label: {
                     Label("Clear Row", systemImage: "trash")
                 }
-                .help("Clears the saved macOS permission row for this Pomo Amp bundle id.")
+                .help("Clears the saved macOS audio-capture permission row for this app bundle id.")
             }
 
             Spacer()
@@ -733,7 +807,12 @@ private final class PomoAmpPermissionAppDragTileView: NSView, NSDraggingSource {
         dragStartLocation = nil
         onDragStarted()
 
-        let draggingItem = NSDraggingItem(pasteboardWriter: appURL as NSURL)
+        let pasteboardItem = NSPasteboardItem()
+        pasteboardItem.setString(appURL.absoluteString, forType: .fileURL)
+        pasteboardItem.setString(appURL.absoluteString, forType: .URL)
+        pasteboardItem.setString(appURL.path, forType: .string)
+
+        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
         let imageSize = NSSize(width: 64, height: 64)
         let imageFrame = NSRect(
             x: bounds.midX - imageSize.width / 2,

--- a/apps/macos/Sources/PomoShared/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/PomoShared/Audio/WebAudioPlayer.swift
@@ -137,13 +137,14 @@ final class WebAudioPlayer: NSObject {
     /// burst of cookie changes during a page load only persists once.
     private var cookieObserver: CookieStoreObserver?
     private var cookieSaveWork: DispatchWorkItem?
+    private var restoredSavedLogin = false
+    private var restoreLoginTask: Task<Void, Never>?
+    private var persistedCookieSignature: String?
 
     override init() {
         super.init()
-        // Re-seed any login saved on disk into the shared store, then keep that
-        // backup current as cookies change — so login survives relaunches and
-        // even a switch between the dev build and the installed release.
-        restoreSavedLogin()
+        // Keep the on-disk backup current. Playback/sign-in explicitly await
+        // restoreSavedLoginIfNeeded() before first navigation.
         startCookiePersistence()
         startAudioScopeFreshnessWatchdog()
     }
@@ -160,7 +161,6 @@ final class WebAudioPlayer: NSObject {
     func play(urlString raw: String, startAt: Double? = nil, knownTitle: String? = nil) {
         let urlString = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !urlString.isEmpty, let base = Self.watchURL(from: urlString) else { return }
-        let url = Self.withAuthUser(base, authUser)
         cancelIdleMemoryPurge()
         cancelBoundaryMemoryPurge()
         cancelPreparedBrowserSwap()
@@ -175,10 +175,16 @@ final class WebAudioPlayer: NSObject {
         resetAudioScope()
         stopNativeAudioScope()
         ensureWebView()
-        log("play \(url.absoluteString)")
-        webView?.load(URLRequest(url: url))
         isPlaying = true
         persistPlaybackSnapshot(force: true, wasPlaying: true)
+
+        Task { @MainActor in
+            await self.restoreSavedLoginIfNeeded()
+            guard self.currentURL == urlString else { return }
+            let url = Self.withAuthUser(base, self.authUser)
+            self.log("play \(url.absoluteString)")
+            self.webView?.load(URLRequest(url: url))
+        }
     }
 
     /// Pick which signed-in Google account to use, and reload.
@@ -244,17 +250,13 @@ final class WebAudioPlayer: NSObject {
     func requestAudioScopePermission() {
         audioScopeError = nil
         nativeAudioScopeSuppressedUntil = 0
-        guard Self.canStartNativeAudioScopeWithoutPrompt() else {
-            nativeAudioScopeEnabledForSession = false
-            audioScopeError = Self.nativeAudioScopePermissionMessage
-            ScreenCaptureAudioPermission.showAssistant(startRequest: false)
-            onStateChange?()
-            return
-        }
+        ScreenCaptureAudioPermission.registerPermissionTarget(reason: "visualizer requested")
         Self.recordNativeAudioScopeUserIntent()
         nativeAudioScopeEnabledForSession = true
         if isPlaying {
             startNativeAudioScope(reason: "visualizer requested", userInitiated: true)
+        } else {
+            ScreenCaptureAudioPermission.showAssistant(startRequest: false)
         }
         onStateChange?()
     }
@@ -279,7 +281,7 @@ final class WebAudioPlayer: NSObject {
     }
 
     func setVisualizerScopeFrameInterval(milliseconds: Int) {
-        let clamped = max(50, min(500, milliseconds))
+        let clamped = max(33, min(500, milliseconds))
         guard audioScopeFrameIntervalMilliseconds != clamped else { return }
         audioScopeFrameIntervalMilliseconds = clamped
         nativeAudioScope.setFrameInterval(milliseconds: clamped)
@@ -942,7 +944,11 @@ final class WebAudioPlayer: NSObject {
         window.delegate = self
         signInWindow = window
 
-        wv.load(URLRequest(url: URL(string: "https://accounts.google.com/ServiceLogin?service=youtube&continue=https%3A%2F%2Fwww.youtube.com%2F")!))
+        Task { @MainActor in
+            await self.restoreSavedLoginIfNeeded()
+            let continueURL = URL(string: "https://www.youtube.com/")!
+            wv.load(URLRequest(url: Self.serviceLoginURL(continueURL: continueURL, accountIndex: self.authUser)))
+        }
         NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
     }
@@ -950,28 +956,52 @@ final class WebAudioPlayer: NSObject {
     /// Borrow the YouTube login from a browser/profile (via the rookie helper)
     /// and reload signed-in. Clears any prior Google/YouTube cookies first so
     /// accounts/profiles don't mix. `browser` nil = all; `profile` e.g. "Profile 1".
-    func importCookies(fromBrowser browser: String?, profile: String?) {
-        Task { @MainActor in _ = await importLogin(fromBrowser: browser, profile: profile) }
+    func importCookies(fromBrowser browser: String?, profile: String?, accountIndex: Int = 0) {
+        Task { @MainActor in
+            _ = await importLogin(fromBrowser: browser, profile: profile, accountIndex: accountIndex)
+        }
     }
 
     /// Awaitable import that returns how many auth cookies were found, so callers
     /// (e.g. the import panel) can report success vs "nothing found". Clears any
     /// prior Google/YouTube cookies first so accounts/profiles don't mix.
     @discardableResult
-    func importLogin(fromBrowser browser: String?, profile: String?) async -> Int {
+    func importLogin(fromBrowser browser: String?, profile: String?, accountIndex: Int = 0) async -> Int {
         ensureWebView()
         guard let webView else { return 0 }
+        let accountIndex = max(0, accountIndex)
         let label = [browser, profile].compactMap { $0 }.joined(separator: " / ")
         log("importing cookies from \(label.isEmpty ? "all browsers" : label)…")
         let store = webView.configuration.websiteDataStore.httpCookieStore
-        let cleared = await Self.clearAuthCookies(store)
         let cookies = await CookieImporter.cookies(fromBrowser: browser, profile: profile)
-        for cookie in cookies { await store.setCookie(cookie) }
-        authUser = 0   // a profile's default account is the intended one
-        log("cleared \(cleared), imported \(cookies.count) cookies")
-        if !currentURL.isEmpty, let base = Self.watchURL(from: currentURL) {
-            webView.load(URLRequest(url: Self.withAuthUser(base, 0)))
+        guard !cookies.isEmpty else {
+            log("import found no cookies; keeping existing login")
+            return 0
         }
+
+        if let restoreLoginTask {
+            await restoreLoginTask.value
+            self.restoreLoginTask = nil
+        }
+        let cleared = await Self.clearAuthCookies(store)
+        for cookie in cookies { await store.setCookie(cookie) }
+        let acceptedCookies = (await store.allCookies()).filter(Self.isPersistableAuthCookie)
+        let persistedCookies = acceptedCookies.isEmpty ? cookies.filter(Self.isPersistableAuthCookie) : acceptedCookies
+        CookieJar.save(persistedCookies)
+        restoredSavedLogin = true
+        persistedCookieSignature = Self.cookieSignature(persistedCookies)
+        cookieSaveWork?.cancel()
+        authUser = accountIndex
+        log("cleared \(cleared), imported \(cookies.count) cookies for account \(accountIndex)")
+        let targetURL: URL
+        if !currentURL.isEmpty, let base = Self.watchURL(from: currentURL) {
+            targetURL = Self.withAuthUser(base, accountIndex)
+        } else if let url = URL(string: "https://www.youtube.com/") {
+            targetURL = Self.withAuthUser(url, accountIndex)
+        } else {
+            return cookies.count
+        }
+        webView.load(URLRequest(url: Self.serviceLoginURL(continueURL: targetURL, accountIndex: accountIndex)))
         return cookies.count
     }
 
@@ -980,8 +1010,14 @@ final class WebAudioPlayer: NSObject {
         ensureWebView()
         guard let webView else { return }
         Task { @MainActor in
+            if let restoreLoginTask = self.restoreLoginTask {
+                await restoreLoginTask.value
+                self.restoreLoginTask = nil
+            }
             let cleared = await Self.clearAuthCookies(webView.configuration.websiteDataStore.httpCookieStore)
             self.authUser = 0
+            self.restoredSavedLogin = true
+            self.persistedCookieSignature = nil
             CookieJar.save([])   // write-through so logout survives an immediate quit
             self.log("logout — cleared \(cleared) cookies")
             if !self.currentURL.isEmpty, let url = Self.watchURL(from: self.currentURL) {
@@ -1009,22 +1045,39 @@ final class WebAudioPlayer: NSObject {
     }
 
     private static func isAuthDomain(_ domain: String) -> Bool {
-        let d = domain.lowercased()
-        return d.contains("youtube.com") || d.contains("google.com") || d.contains("google.")
+        let d = domain
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        return d == "youtube.com" || d.hasSuffix(".youtube.com")
+            || d == "google.com" || d.hasSuffix(".google.com")
     }
 
     // MARK: - Login persistence (cookies on disk)
 
-    /// Re-inject any login saved on a prior run into the shared default store, so
-    /// a one-time sign-in is reloaded on every launch (and across builds).
-    private func restoreSavedLogin() {
-        let saved = CookieJar.load()
-        guard !saved.isEmpty else { return }
-        let store = WKWebsiteDataStore.default().httpCookieStore
-        Task { @MainActor in
+    /// Re-inject any login saved on a prior run into the shared default store.
+    /// First navigation waits for this so YouTube does not boot signed-out and
+    /// overwrite the imported session during hydration.
+    private func restoreSavedLoginIfNeeded() async {
+        if restoredSavedLogin { return }
+        if let restoreLoginTask {
+            await restoreLoginTask.value
+            return
+        }
+
+        let task = Task { @MainActor in
+            defer { self.restoredSavedLogin = true }
+            let saved = CookieJar.load()
+            guard !saved.isEmpty else { return }
+            let store = self.webView?.configuration.websiteDataStore.httpCookieStore
+                ?? WKWebsiteDataStore.default().httpCookieStore
             for cookie in saved { await store.setCookie(cookie) }
+            self.persistedCookieSignature = Self.cookieSignature(saved)
             self.log("restored \(saved.count) login cookies from disk")
         }
+
+        restoreLoginTask = task
+        await task.value
+        restoreLoginTask = nil
     }
 
     /// Watch the shared cookie store and mirror the auth cookies to disk whenever
@@ -1052,8 +1105,40 @@ final class WebAudioPlayer: NSObject {
         let store = WKWebsiteDataStore.default().httpCookieStore
         Task { @MainActor in
             let all = await store.allCookies()
-            CookieJar.save(all.filter { Self.isAuthDomain($0.domain) })
+            let cookies = all.filter(Self.isPersistableAuthCookie)
+            guard !cookies.isEmpty else { return }
+            let signature = Self.cookieSignature(cookies)
+            guard signature != self.persistedCookieSignature else { return }
+            CookieJar.save(cookies)
+            self.persistedCookieSignature = signature
+            self.log("persisted \(cookies.count) login cookies")
         }
+    }
+
+    private static func isPersistableAuthCookie(_ cookie: HTTPCookie) -> Bool {
+        guard isAuthDomain(cookie.domain), !cookie.value.isEmpty else { return false }
+        if let expires = cookie.expiresDate, expires <= Date() { return false }
+        return true
+    }
+
+    private static func cookieSignature(_ cookies: [HTTPCookie]) -> String {
+        cookies
+            .map { cookie in
+                let expires = cookie.expiresDate?.timeIntervalSince1970 ?? 0
+                return "\(cookie.domain)\t\(cookie.path)\t\(cookie.name)\t\(cookie.value)\t\(expires)"
+            }
+            .sorted()
+            .joined(separator: "\n")
+    }
+
+    private static func serviceLoginURL(continueURL: URL, accountIndex: Int) -> URL {
+        var components = URLComponents(string: "https://accounts.google.com/ServiceLogin")!
+        components.queryItems = [
+            URLQueryItem(name: "service", value: "youtube"),
+            URLQueryItem(name: "continue", value: continueURL.absoluteString),
+            URLQueryItem(name: "authuser", value: String(max(0, accountIndex))),
+        ]
+        return components.url!
     }
 
     // MARK: - Video-pane context menu + import panel
@@ -1155,8 +1240,8 @@ final class WebAudioPlayer: NSObject {
         let view = CookieImportPanel(
             account: account,
             profiles: CookieImporter.detectedProfiles(),
-            onImport: { [weak self] browser, profile in
-                await self?.importLogin(fromBrowser: browser, profile: profile) ?? 0
+            onImport: { [weak self] browser, profile, accountIndex in
+                await self?.importLogin(fromBrowser: browser, profile: profile, accountIndex: accountIndex) ?? 0
             },
             onClose: { [weak self] in self?.importLoginWindow?.close() }
         )
@@ -1244,7 +1329,7 @@ final class WebAudioPlayer: NSObject {
     }
 
     private static func setAudioScopeFrameIntervalJS(_ milliseconds: Int) -> String {
-        "window.__pomoScopeIntervalMs=\(max(50, min(500, milliseconds)));"
+        "window.__pomoScopeIntervalMs=\(max(33, min(500, milliseconds)));"
     }
 
     private static let suspendAudioScopeJS = """
@@ -1785,7 +1870,7 @@ final class WebAudioPlayer: NSObject {
                     }
                   }
                   if (v.__pomoScopeTimer) clearInterval(v.__pomoScopeTimer);
-                  v.__pomoScopeTimer = setInterval(tick, Math.max(50, Math.min(500, Number(window.__pomoScopeIntervalMs) || 100)));
+                  v.__pomoScopeTimer = setInterval(tick, Math.max(33, Math.min(500, Number(window.__pomoScopeIntervalMs) || 100)));
                   tick();
                   post('scope:started');
                 } catch(e) {
@@ -2267,11 +2352,7 @@ final class WebAudioPlayer: NSObject {
         guard isPlaying else { return }
         guard !nativeAudioScope.isActive else { return }
         if userInitiated {
-            guard Self.canStartNativeAudioScopeWithoutPrompt() else {
-                noteNativeAudioScopePermissionNeeded(reason: reason)
-                ScreenCaptureAudioPermission.showAssistant(startRequest: false)
-                return
-            }
+            ScreenCaptureAudioPermission.registerPermissionTarget(reason: reason)
             Self.recordNativeAudioScopeUserIntent()
             nativeAudioScopeEnabledForSession = true
         } else if !nativeAudioScopeEnabledForSession {
@@ -2378,6 +2459,9 @@ final class WebAudioPlayer: NSObject {
             audioScope = nil
             silentScopeFrames = 0
             nonSilentScopeFrames = 0
+            if !alreadyAllowed {
+                ScreenCaptureAudioPermission.showAssistant(startRequest: false)
+            }
             return
         }
         let lowercased = error.lowercased()
@@ -2404,8 +2488,8 @@ final class WebAudioPlayer: NSObject {
     }
 
     private static func shouldAutoStartNativeAudioScope() -> Bool {
-        canStartNativeAudioScopeWithoutPrompt()
-            && (hasSuccessfulNativeAudioScopeAccessForCurrentExecutable() || hasNativeAudioScopeUserIntent())
+        hasSuccessfulNativeAudioScopeAccessForCurrentExecutable()
+            || (canStartNativeAudioScopeWithoutPrompt() && hasNativeAudioScopeUserIntent())
     }
 
     private static func canStartNativeAudioScopeWithoutPrompt() -> Bool {
@@ -2542,6 +2626,7 @@ final class WebAudioPlayer: NSObject {
             avatarView?.image = nil
             avatarView?.isHidden = true
         }
+        onStateChange?()
     }
 
     private func loadAvatar(_ urlString: String) {
@@ -2553,6 +2638,7 @@ final class WebAudioPlayer: NSObject {
                 self.account.avatar = image
                 self.avatarView?.image = image
                 self.avatarView?.isHidden = !self.account.signedIn
+                self.onStateChange?()
             }
         }.resume()
     }

--- a/apps/macos/Sources/PomoShared/Control/AgentControl.swift
+++ b/apps/macos/Sources/PomoShared/Control/AgentControl.swift
@@ -17,7 +17,7 @@ enum PomoCommand {
     case audioPrev
     case sessionAudio(SessionType, String?)
     case login
-    case importCookies(browser: String?, profile: String?)
+    case importCookies(browser: String?, profile: String?, accountIndex: Int)
     case logout
     case selectAccount(Int)
     case videoShow
@@ -73,9 +73,11 @@ enum PomoCommand {
         case "login":
             switch arg {
             case "import":
+                let accountValue = query?.first(where: { ["account", "authuser", "authUser"].contains($0.name) })?.value
                 self = .importCookies(
                     browser: query?.first(where: { $0.name == "browser" })?.value,
-                    profile: query?.first(where: { $0.name == "profile" })?.value
+                    profile: query?.first(where: { $0.name == "profile" })?.value,
+                    accountIndex: max(0, Int(accountValue ?? "") ?? 0)
                 )
             case "account":
                 guard path.count > 1, let index = Int(path[1]) else { return nil }

--- a/apps/macos/Sources/PomoShared/Core/PomoSettings.swift
+++ b/apps/macos/Sources/PomoShared/Core/PomoSettings.swift
@@ -404,21 +404,21 @@ enum PomoAmpVisualizerMode: String, Codable, CaseIterable, Identifiable {
         case .smooth:
             return PomoAmpVisualizerProfile(
                 modeName: "smooth",
-                skinFPS: 24,
+                skinFPS: 45,
                 inspectorFPS: 8,
-                scopeFrameIntervalMilliseconds: 66,
-                canvasLiveDelayMilliseconds: 42,
+                scopeFrameIntervalMilliseconds: 33,
+                canvasLiveDelayMilliseconds: 16,
                 canvasSilentDelayMilliseconds: 180,
                 canvasIdleDelayMilliseconds: 900,
-                canvasMaxDevicePixelRatio: 1.7
+                canvasMaxDevicePixelRatio: 1.6
             )
         case .balanced:
             return PomoAmpVisualizerProfile(
                 modeName: "balanced",
-                skinFPS: 15,
+                skinFPS: 30,
                 inspectorFPS: 6,
-                scopeFrameIntervalMilliseconds: 100,
-                canvasLiveDelayMilliseconds: 67,
+                scopeFrameIntervalMilliseconds: 33,
+                canvasLiveDelayMilliseconds: 33,
                 canvasSilentDelayMilliseconds: 250,
                 canvasIdleDelayMilliseconds: 1200,
                 canvasMaxDevicePixelRatio: 1.35

--- a/apps/macos/Sources/PomoShared/MenuBar/MenuBarController.swift
+++ b/apps/macos/Sources/PomoShared/MenuBar/MenuBarController.swift
@@ -25,6 +25,10 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
     var onToggleAudio: (() -> Void)?
     var onStopAudio: (() -> Void)?
     var onPlayFavorite: ((Favorite) -> Void)?
+    var onOpenPomoAmp: (() -> Void)?
+    var onQuitPomoAmp: (() -> Void)?
+    var isPomoAmpRunning: (() -> Bool)?
+    var hasPomoAmpCompanion: (() -> Bool)?
 
     init(model: TimerModel, settings: PomoSettings, audio: AudioController, favorites: FavoritesStore) {
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -68,61 +72,10 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         } else { try? entry.data(using: .utf8)?.write(to: url) }
     }
 
-    /// The Pomo ring mark, drawn as a template image so the menu bar tints it
-    /// to match the system appearance. The outer stroke doubles as an elapsed
-    /// timer ring while the tick + centre dot keep the app-mark silhouette.
-    private static func ringMarkImage(progress rawProgress: Double, isPaused: Bool, isIdle: Bool) -> NSImage {
-        let progress = CGFloat(max(0, min(1, rawProgress)))
-        let image = NSImage(size: NSSize(width: 18, height: 18), flipped: false) { _ in
-            let center = NSPoint(x: 9, y: 9)
-            let radius: CGFloat = 6.0
-
-            let ring = NSBezierPath()
-            ring.appendArc(withCenter: center, radius: radius, startAngle: 0, endAngle: 360)
-            ring.lineWidth = 1.3
-            NSColor.black.withAlphaComponent(isIdle ? 0.42 : 0.24).setStroke()
-            ring.stroke()
-
-            if !isIdle {
-                let arc = NSBezierPath()
-                let capped = min(progress, 0.999)
-                arc.appendArc(
-                    withCenter: center,
-                    radius: radius,
-                    startAngle: 90,
-                    endAngle: 90 - capped * 360,
-                    clockwise: true
-                )
-                arc.lineWidth = 1.9
-                arc.lineCapStyle = .round
-                NSColor.black.withAlphaComponent(isPaused ? 0.62 : 1.0).setStroke()
-                arc.stroke()
-            }
-
-            let tick = NSBezierPath()
-            tick.move(to: NSPoint(x: center.x, y: center.y + radius + 1.8))
-            tick.line(to: NSPoint(x: center.x, y: center.y + radius - 0.4))
-            tick.lineWidth = 1.5
-            tick.lineCapStyle = .round
-            NSColor.black.setStroke()
-            tick.stroke()
-
-            let dotRadius: CGFloat = 1.4
-            let dotRect = NSRect(x: center.x - dotRadius, y: center.y - dotRadius,
-                                 width: dotRadius * 2, height: dotRadius * 2)
-            NSColor.black.setFill()
-            NSBezierPath(ovalIn: dotRect).fill()
-
-            return true
-        }
-        image.isTemplate = true
-        return image
-    }
-
     /// Update the countdown title. Called from `TimerModel.onTick`.
     func refresh() {
         guard let button = statusItem.button else { return }
-        button.image = MenuBarController.ringMarkImage(
+        button.image = PomoStatusIcon.timerRing(
             progress: model.progress,
             isPaused: model.isPaused,
             isIdle: model.isIdle
@@ -195,7 +148,15 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
                 },
                 onToggleAudio: { [weak self] in self?.onToggleAudio?() },
                 onStopAudio: { [weak self] in self?.onStopAudio?() },
-                onPlayFavorite: { [weak self] favorite in self?.onPlayFavorite?(favorite) }
+                onPlayFavorite: { [weak self] favorite in self?.onPlayFavorite?(favorite) },
+                onOpenPomoAmp: { [weak self] in
+                    self?.popover?.performClose(nil)
+                    self?.onOpenPomoAmp?()
+                },
+                isPomoAmpRunning: { [weak self] in self?.isPomoAmpRunning?() == true },
+                hasPomoAmpCompanion: { [weak self] in
+                    self?.hasPomoAmpCompanion?() == true || self?.isPomoAmpRunning?() == true
+                }
             )
         )
         host.sizingOptions = .preferredContentSize
@@ -262,6 +223,17 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         sound.target = self
         sound.state = settings.soundEnabled ? .on : .off
         menu.addItem(sound)
+
+        if hasPomoAmpCompanion?() == true || isPomoAmpRunning?() == true {
+            let isRunning = isPomoAmpRunning?() == true
+            let amp = NSMenuItem(
+                title: isRunning ? "Quit Pomo Amp" : "Open Pomo Amp",
+                action: isRunning ? #selector(quitPomoAmp) : #selector(openPomoAmp),
+                keyEquivalent: ""
+            )
+            amp.target = self
+            menu.addItem(amp)
+        }
 
         menu.addItem(.separator())
 
@@ -385,6 +357,8 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
     @objc private func openSettings() { onOpenSettings?() }
     @objc private func openStats() { onOpenStats?() }
     @objc private func quit() { onQuit?() }
+    @objc private func openPomoAmp() { onOpenPomoAmp?() }
+    @objc private func quitPomoAmp() { onQuitPomoAmp?() }
 
     @objc private func toggleSound() {
         settings.soundEnabled.toggle()

--- a/apps/macos/Sources/PomoShared/MenuBar/MenuPopoverView.swift
+++ b/apps/macos/Sources/PomoShared/MenuBar/MenuPopoverView.swift
@@ -26,6 +26,9 @@ struct MenuPopoverView: View {
     var onToggleAudio: () -> Void
     var onStopAudio: () -> Void
     var onPlayFavorite: (Favorite) -> Void
+    var onOpenPomoAmp: () -> Void
+    var isPomoAmpRunning: () -> Bool
+    var hasPomoAmpCompanion: () -> Bool
 
     @Environment(\.colorScheme) private var scheme
     @State private var editingIntent = false
@@ -771,6 +774,14 @@ struct MenuPopoverView: View {
             Divider().overlay(dividerColor)
             HStack(spacing: HudSpacing.md) {
                 iconButton("macwindow", help: "Show HUD", action: onShowHUD)
+                if hasPomoAmpCompanion() || isPomoAmpRunning() {
+                    iconButton(
+                        "waveform",
+                        help: isPomoAmpRunning() ? "Show Pomo Amp" : "Open Pomo Amp",
+                        active: isPomoAmpRunning(),
+                        action: onOpenPomoAmp
+                    )
+                }
                 Spacer()
                 iconButton(
                     settings.soundEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill",

--- a/apps/macos/Sources/PomoShared/MenuBar/PomoStatusIcon.swift
+++ b/apps/macos/Sources/PomoShared/MenuBar/PomoStatusIcon.swift
@@ -1,0 +1,125 @@
+import AppKit
+
+enum PomoStatusIcon {
+    static func timerRing(
+        progress rawProgress: Double = 0,
+        isPaused: Bool = false,
+        isIdle: Bool = true,
+        size: CGFloat = 18
+    ) -> NSImage {
+        let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+            let scale = min(rect.width, rect.height) / 18
+            let origin = NSPoint(
+                x: rect.midX - 9 * scale,
+                y: rect.midY - 9 * scale
+            )
+            func point(_ x: CGFloat, _ y: CGFloat) -> NSPoint {
+                NSPoint(x: origin.x + x * scale, y: origin.y + y * scale)
+            }
+
+            let progress = CGFloat(max(0, min(1, rawProgress)))
+            let center = point(9, 9)
+            let radius: CGFloat = 6 * scale
+
+            let ring = NSBezierPath()
+            ring.appendArc(withCenter: center, radius: radius, startAngle: 0, endAngle: 360)
+            ring.lineWidth = 1.3 * scale
+            NSColor.black.withAlphaComponent(isIdle ? 0.42 : 0.24).setStroke()
+            ring.stroke()
+
+            if !isIdle {
+                let arc = NSBezierPath()
+                let capped = min(progress, 0.999)
+                arc.appendArc(
+                    withCenter: center,
+                    radius: radius,
+                    startAngle: 90,
+                    endAngle: 90 - capped * 360,
+                    clockwise: true
+                )
+                arc.lineWidth = 1.9 * scale
+                arc.lineCapStyle = .round
+                NSColor.black.withAlphaComponent(isPaused ? 0.62 : 1.0).setStroke()
+                arc.stroke()
+            }
+
+            let tick = NSBezierPath()
+            tick.move(to: point(9, 16.8))
+            tick.line(to: point(9, 14.6))
+            tick.lineWidth = 1.5 * scale
+            tick.lineCapStyle = .round
+            NSColor.black.setStroke()
+            tick.stroke()
+
+            let dotRadius: CGFloat = 1.4 * scale
+            let dotRect = NSRect(
+                x: center.x - dotRadius,
+                y: center.y - dotRadius,
+                width: dotRadius * 2,
+                height: dotRadius * 2
+            )
+            NSColor.black.setFill()
+            NSBezierPath(ovalIn: dotRect).fill()
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+
+    static func ampPlayClock(active: Bool, size: CGFloat = 18) -> NSImage {
+        let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+            let scale = min(rect.width, rect.height) / 18
+            let origin = NSPoint(
+                x: rect.midX - 9 * scale,
+                y: rect.midY - 9 * scale
+            )
+            func point(_ x: CGFloat, _ y: CGFloat) -> NSPoint {
+                NSPoint(x: origin.x + x * scale, y: origin.y + y * scale)
+            }
+
+            let center = point(9, 9)
+            let radius: CGFloat = 6 * scale
+            let alpha = active ? 1.0 : 0.58
+
+            let ring = NSBezierPath()
+            ring.appendArc(withCenter: center, radius: radius, startAngle: 0, endAngle: 360)
+            ring.lineWidth = 1.45 * scale
+            NSColor.black.withAlphaComponent(alpha).setStroke()
+            ring.stroke()
+
+            let tick = NSBezierPath()
+            tick.move(to: point(9, 16.8))
+            tick.line(to: point(9, 14.6))
+            tick.lineWidth = 1.45 * scale
+            tick.lineCapStyle = .round
+            NSColor.black.withAlphaComponent(alpha).setStroke()
+            tick.stroke()
+
+            let play = NSBezierPath()
+            play.move(to: point(7.25, 5.7))
+            play.line(to: point(7.25, 12.3))
+            play.line(to: point(12.4, 9))
+            play.close()
+            NSColor.black.withAlphaComponent(active ? 1.0 : 0.7).setFill()
+            play.fill()
+
+            if active {
+                let dotRadius: CGFloat = 1.55 * scale
+                let dotCenter = point(14.35, 4.25)
+                let dotRect = NSRect(
+                    x: dotCenter.x - dotRadius,
+                    y: dotCenter.y - dotRadius,
+                    width: dotRadius * 2,
+                    height: dotRadius * 2
+                )
+                NSColor.black.setFill()
+                NSBezierPath(ovalIn: dotRect).fill()
+            }
+
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+}

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpAppDelegate.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpAppDelegate.swift
@@ -170,8 +170,8 @@ public final class PomoAmpAppDelegate: NSObject, NSApplicationDelegate {
             }
         case .login:
             audio.signIn()
-        case .importCookies(let browser, let profile):
-            audio.importCookies(browser: browser, profile: profile)
+        case .importCookies(let browser, let profile, let accountIndex):
+            audio.importCookies(browser: browser, profile: profile, accountIndex: accountIndex)
         case .logout:
             audio.clearLogin()
         case .selectAccount(let index):
@@ -211,9 +211,9 @@ public final class PomoAmpAppDelegate: NSObject, NSApplicationDelegate {
 
     private func openPomo() {
         guard let url = URL(string: "pomo://toggle-hud") else { return }
-        if let siblingPomoApp = siblingPomoAppURL() {
+        if let pomoApp = pomoAppURL() {
             let configuration = NSWorkspace.OpenConfiguration()
-            NSWorkspace.shared.open([url], withApplicationAt: siblingPomoApp, configuration: configuration) { _, error in
+            NSWorkspace.shared.open([url], withApplicationAt: pomoApp, configuration: configuration) { _, error in
                 if error != nil {
                     NSWorkspace.shared.open(url)
                 }
@@ -224,11 +224,29 @@ public final class PomoAmpAppDelegate: NSObject, NSApplicationDelegate {
         NSWorkspace.shared.open(url)
     }
 
-    private func siblingPomoAppURL() -> URL? {
+    private func pomoAppURL() -> URL? {
+        let bundleURL = Bundle.main.bundleURL
+        let nestedHost = bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        if nestedHost.lastPathComponent == "Pomo.app",
+           appBundleExists(at: nestedHost) {
+            return nestedHost
+        }
+
         let sibling = Bundle.main.bundleURL
             .deletingLastPathComponent()
             .appendingPathComponent("Pomo.app", isDirectory: true)
-        return FileManager.default.fileExists(atPath: sibling.path) ? sibling : nil
+        if appBundleExists(at: sibling) {
+            return sibling
+        }
+
+        return nil
+    }
+
+    private func appBundleExists(at url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.appendingPathComponent("Contents/Info.plist").path)
     }
 
     private func preferredAudioURL() -> String {

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpDefaultSkinHTML.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpDefaultSkinHTML.swift
@@ -786,13 +786,13 @@ enum PomoAmpDefaultSkinHTML {
     var viz = emptyViz;
     var profile = {
       modeName: "balanced",
-      skinFPS: 15,
-      canvasLiveDelayMilliseconds: 67,
+      skinFPS: 30,
+      canvasLiveDelayMilliseconds: 33,
       canvasSilentDelayMilliseconds: 250,
       canvasIdleDelayMilliseconds: 1200,
       canvasMaxDevicePixelRatio: 1.35
     };
-    const skinBuild = "1.1.8";
+    const skinBuild = "1.1.10";
     if (localStorage.getItem("pomoAmp.defaultSkin.build") !== skinBuild) {
       localStorage.setItem("pomoAmp.defaultSkin.build", skinBuild);
       localStorage.setItem("pomoAmp.defaultSkin.preset", "0");
@@ -807,6 +807,7 @@ enum PomoAmpDefaultSkinHTML {
     const gain = { bandPeaks: [], wavePeak: 0.08, rmsPeak: 0.05, energy: 0 };
     var drawTimer = 0;
     var drawScheduled = false;
+    var lastDrawTime = 0;
     var vizSerial = 0;
     const canvasCache = new WeakMap();
     const vizMemo = {
@@ -1621,7 +1622,7 @@ enum PomoAmpDefaultSkinHTML {
       if (document.hidden) return 1000;
       if (!state.isPlaying) return Number(profile.canvasIdleDelayMilliseconds) || 1200;
       if (!hasLiveViz()) return Number(profile.canvasSilentDelayMilliseconds) || 250;
-      return Number(profile.canvasLiveDelayMilliseconds) || 67;
+      return Number(profile.canvasLiveDelayMilliseconds) || 33;
     }
 
     function scheduleDraw(delay = drawDelay()) {
@@ -1631,13 +1632,23 @@ enum PomoAmpDefaultSkinHTML {
         clearTimeout(drawTimer);
       }
       drawScheduled = true;
-      drawTimer = setTimeout(() => {
+      const requestDraw = () => {
         drawTimer = 0;
-        requestAnimationFrame(() => {
+        requestAnimationFrame((timestamp) => {
+          if (nextDelay > 0 && lastDrawTime > 0) {
+            const remaining = nextDelay - (timestamp - lastDrawTime);
+            if (remaining > 1) {
+              drawTimer = setTimeout(requestDraw, remaining);
+              return;
+            }
+          }
+          lastDrawTime = timestamp;
           drawScheduled = false;
           drawFrame();
         });
-      }, nextDelay);
+      };
+      const elapsed = lastDrawTime > 0 ? performance.now() - lastDrawTime : nextDelay;
+      drawTimer = setTimeout(requestDraw, Math.max(0, nextDelay - elapsed));
     }
 
     function drawFrame() {

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpHUDRootView.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpHUDRootView.swift
@@ -169,6 +169,10 @@ struct PomoAmpHUDRootView: View {
                     onHide?()
                 }
                 Spacer(minLength: 0)
+                chromeButton("doc.on.clipboard", help: "Paste YouTube URL") {
+                    onPasteURL()
+                }
+                openPomoButton()
             }
         }
         .frame(height: 22)
@@ -177,14 +181,6 @@ struct PomoAmpHUDRootView: View {
 
     private var shadeControlRow: some View {
         ZStack {
-            HStack(spacing: 5) {
-                chromeButton("link", help: "Paste YouTube URL") {
-                    onPasteURL()
-                }
-                openPomoButton()
-                Spacer(minLength: 0)
-            }
-
             HStack(spacing: 5) {
                 chromeButton("backward.end.fill", help: "Previous timestamp section") {
                     onPreviousSection()
@@ -249,8 +245,6 @@ struct PomoAmpHUDRootView: View {
                 onHide?()
             }
 
-            openPomoButton()
-
             dragTitle
 
             chromeButton(audio.videoOpen ? "rectangle.fill" : "play.rectangle", help: audio.videoOpen ? "Hide video" : "Show video") {
@@ -284,6 +278,8 @@ struct PomoAmpHUDRootView: View {
             ) {
                 onToggleBig()
             }
+
+            openPomoButton()
         }
         .padding(.horizontal, 7)
         .frame(height: PomoAmpChrome.titleBarHeight)
@@ -370,20 +366,12 @@ struct PomoAmpHUDRootView: View {
 
     private func openPomoButton() -> some View {
         Button(action: onOpenPomo) {
-            Group {
-                if let icon = Self.pomoIcon {
-                    Image(nsImage: icon)
-                        .resizable()
-                        .interpolation(.high)
-                        .aspectRatio(contentMode: .fit)
-                        .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
-                } else {
-                    Image(systemName: "hourglass")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundStyle(chromeButtonForeground(.normal))
-                }
-            }
-            .frame(width: 14, height: 14)
+            Image(nsImage: PomoStatusIcon.timerRing(size: 16))
+                .renderingMode(.template)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .foregroundStyle(chromeButtonForeground(.normal))
+                .frame(width: 16, height: 16)
             .frame(width: 24, height: 22)
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -399,16 +387,6 @@ struct PomoAmpHUDRootView: View {
         .buttonStyle(.plain)
         .help("Show / Hide Pomo")
     }
-
-    private static let pomoIcon: NSImage? = {
-        if let image = NSImage(named: "AppIcon") {
-            return image
-        }
-        guard let url = Bundle.main.url(forResource: "AppIcon", withExtension: "icns") else {
-            return nil
-        }
-        return NSImage(contentsOf: url)
-    }()
 
     private func chromeButtonFill(_ tone: ChromeButtonTone) -> AnyShapeStyle {
         switch tone {

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpMenuBarController.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpMenuBarController.swift
@@ -37,14 +37,16 @@ final class PomoAmpMenuBarController: NSObject, NSPopoverDelegate {
 
     func refresh() {
         guard let button = statusItem.button else { return }
-        button.title = audio.isPlaying ? " Pomo Amp ▶" : " Pomo Amp"
-        button.image = Self.icon(active: audio.isPlaying)
+        button.title = ""
+        button.image = PomoStatusIcon.ampPlayClock(active: audio.isPlaying, size: 18)
+        button.toolTip = audio.isPlaying ? "Playing" : "Music"
     }
 
     private func configureButton() {
         guard let button = statusItem.button else { return }
-        button.imagePosition = .imageLeading
-        button.font = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize - 1, weight: .semibold)
+        statusItem.length = NSStatusItem.squareLength
+        button.imagePosition = .imageOnly
+        button.imageScaling = .scaleProportionallyDown
         button.target = self
         button.action = #selector(handleClick)
         button.sendAction(on: [.leftMouseUp])
@@ -58,26 +60,6 @@ final class PomoAmpMenuBarController: NSObject, NSPopoverDelegate {
             }
             return nil
         }
-    }
-
-    private static func icon(active: Bool) -> NSImage {
-        let image = NSImage(size: NSSize(width: 18, height: 18), flipped: false) { _ in
-            let color = NSColor.black.withAlphaComponent(active ? 1 : 0.62)
-            color.setStroke()
-            color.setFill()
-            let stem = NSBezierPath()
-            stem.move(to: NSPoint(x: 11, y: 4))
-            stem.line(to: NSPoint(x: 11, y: 13))
-            stem.line(to: NSPoint(x: 15, y: 14))
-            stem.lineWidth = 1.6
-            stem.lineCapStyle = .round
-            stem.lineJoinStyle = .round
-            stem.stroke()
-            NSBezierPath(ovalIn: NSRect(x: 4, y: 3, width: 7, height: 5)).fill()
-            return true
-        }
-        image.isTemplate = true
-        return image
     }
 
     @objc private func handleClick() {
@@ -156,7 +138,7 @@ final class PomoAmpMenuBarController: NSObject, NSPopoverDelegate {
         menu.autoenablesItems = false
 
         addItem("Show / Hide Pomo Amp", to: menu, action: #selector(toggleHUD))
-        addItem("Show / Hide Pomo", to: menu, action: #selector(openPomo), image: Self.pomoIcon)
+        addItem("Show / Hide Pomo", to: menu, action: #selector(openPomo), image: PomoStatusIcon.timerRing(size: 16))
         menu.addItem(.separator())
         addItem(audio.isPlaying ? "Pause" : "Play", to: menu, action: #selector(toggleAudio))
         addItem("Previous Timestamp Section", to: menu, action: #selector(previousSection))
@@ -182,18 +164,6 @@ final class PomoAmpMenuBarController: NSObject, NSPopoverDelegate {
         item.image = image
         menu.addItem(item)
     }
-
-    private static let pomoIcon: NSImage? = {
-        if let image = NSImage(named: "AppIcon") {
-            image.size = NSSize(width: 16, height: 16)
-            return image
-        }
-        guard let url = Bundle.main.url(forResource: "AppIcon", withExtension: "icns"),
-              let image = NSImage(contentsOf: url)
-        else { return nil }
-        image.size = NSSize(width: 16, height: 16)
-        return image
-    }()
 
     private func faceItem() -> NSMenuItem {
         let item = NSMenuItem(title: "Face", action: nil, keyEquivalent: "")

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpMenuPopoverView.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpMenuPopoverView.swift
@@ -341,20 +341,12 @@ struct PomoAmpMenuPopoverView: View {
 
     private var pomoButton: some View {
         Button(action: onTogglePomo) {
-            Group {
-                if let icon = Self.pomoIcon {
-                    Image(nsImage: icon)
-                        .resizable()
-                        .interpolation(.high)
-                        .aspectRatio(contentMode: .fit)
-                        .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-                } else {
-                    Image(systemName: "timer")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundStyle(PomoBrand.accent)
-                }
-            }
-            .frame(width: 16, height: 16)
+            Image(nsImage: PomoStatusIcon.timerRing(size: 16))
+                .renderingMode(.template)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .foregroundStyle(PomoBrand.accent)
+                .frame(width: 16, height: 16)
             .frame(width: 30, height: 26)
             .background(
                 RoundedRectangle(cornerRadius: 7, style: .continuous)
@@ -428,16 +420,6 @@ struct PomoAmpMenuPopoverView: View {
         guard let host = URL(string: currentURL)?.host else { return "youtube deck" }
         return host.replacingOccurrences(of: "www.", with: "")
     }
-
-    private static let pomoIcon: NSImage? = {
-        if let image = NSImage(named: "AppIcon") {
-            return image
-        }
-        guard let url = Bundle.main.url(forResource: "AppIcon", withExtension: "icns") else {
-            return nil
-        }
-        return NSImage(contentsOf: url)
-    }()
 
     private static func shortURL(_ raw: String) -> String {
         guard let url = URL(string: raw), let host = url.host else { return raw }

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpSkinStore.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpSkinStore.swift
@@ -66,7 +66,7 @@ public enum PomoAmpSkinStore {
         try? PomoAmpDefaultSkinHTML.html.write(to: directory.appendingPathComponent("index.html"), atomically: true, encoding: .utf8)
     }
 
-    private static let exampleVersion = "1.1.9"
+    private static let exampleVersion = "1.1.10"
 
     private static let exampleManifest = """
     {

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpSkinWebView.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpSkinWebView.swift
@@ -304,7 +304,7 @@ struct PomoAmpSkinWebView: NSViewRepresentable {
         func sendViz(force: Bool = false) {
             guard let webView, let viz else { return }
             if !force {
-                let fps = max(1.0, profile?.skinFPS ?? 15.0)
+                let fps = max(1.0, profile?.skinFPS ?? 30.0)
                 let minInterval = viz.isPlaying ? 1.0 / fps : 1.0
                 guard viz.hostTime - lastVizDispatchHostTime >= minInterval else { return }
             }

--- a/apps/macos/Sources/PomoShared/Settings/CookieImportPanel.swift
+++ b/apps/macos/Sources/PomoShared/Settings/CookieImportPanel.swift
@@ -9,7 +9,7 @@ struct CookieImportPanel: View {
     var account: AccountStatus
     var profiles: [CookieImporter.BrowserProfile]
     /// Imports auth cookies from the given browser/profile; returns how many it found.
-    var onImport: (String, String?) async -> Int
+    var onImport: (String, String?, Int) async -> Int
     var onClose: () -> Void
 
     private struct Browser: Identifiable {
@@ -72,9 +72,11 @@ struct CookieImportPanel: View {
     @State private var importedCount = 0
     @State private var confirmed = false
     @State private var hovered: String?
+    @State private var selectedAccountIndex = 0
 
     @Environment(\.colorScheme) private var scheme
     private var pal: AppPalette { .resolve(scheme) }
+    private let accountSlots = Array(0...3)
 
     var body: some View {
         VStack(alignment: .leading, spacing: HudSpacing.xl) {
@@ -115,6 +117,8 @@ struct CookieImportPanel: View {
                 .foregroundStyle(pal.muted)
                 .fixedSize(horizontal: false, vertical: true)
 
+            accountPicker
+
             ScrollView {
                 VStack(alignment: .leading, spacing: HudSpacing.md) {
                     if !profileTargets.isEmpty {
@@ -138,13 +142,30 @@ struct CookieImportPanel: View {
                 }
                 .padding(.vertical, 1)
             }
-            .frame(maxHeight: 292)
+            .frame(height: 292)
 
             HStack {
                 Spacer()
                 button("Cancel", action: onClose)
             }
         }
+    }
+
+    private var accountPicker: some View {
+        VStack(alignment: .leading, spacing: HudSpacing.sm) {
+            sectionLabel("Google Account")
+            Picker("", selection: $selectedAccountIndex) {
+                ForEach(accountSlots, id: \.self) { index in
+                    Text(accountLabel(index)).tag(index)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private func accountLabel(_ index: Int) -> String {
+        index == 0 ? "Default" : "\(index + 1)"
     }
 
     private func sectionLabel(_ title: String) -> some View {
@@ -314,7 +335,7 @@ struct CookieImportPanel: View {
         importedCount = 0
         phase = .working
         Task {
-            let count = await onImport(target.browser, target.profile)
+            let count = await onImport(target.browser, target.profile, selectedAccountIndex)
             importedCount = count
             // The reload + masthead read is async; give it a moment to confirm.
             if count > 0 {

--- a/apps/macos/scripts/build-dmg.sh
+++ b/apps/macos/scripts/build-dmg.sh
@@ -29,13 +29,14 @@ usage() {
   cat <<EOF
 Usage: build-dmg.sh [--debug] [--local] [--no-build] [--app PATH] [--amp-app PATH] [--output PATH] [--volname NAME]
 
-Builds, signs, notarizes, and packages Pomo.app plus Pomo Amp.app into a drag-to-Applications DMG.
+Builds, signs, notarizes, and packages one visible Pomo.app into a drag-to-Applications DMG.
+Pomo Amp is embedded as Pomo.app/Contents/Helpers/Pomo Amp.app.
 
   --debug          Build debug apps before packaging
   --local          Build a local unsigned smoke DMG; skips signing and notarization
   --no-build       Package existing app bundles
   --app PATH       Pomo app bundle to build/package (default: $app_path)
-  --amp-app PATH   Pomo Amp app bundle to build/package (default: $amp_app_path)
+  --amp-app PATH   Pomo Amp helper bundle to embed (default: $amp_app_path)
   --output PATH    DMG output path (default: $dmg_path)
   --volname NAME   Mounted volume name (default: $volname)
 
@@ -46,6 +47,40 @@ Environment:
   POMO_SKIP_SIGN=1      Skip signing
   POMO_SKIP_NOTARIZE=1  Skip notarization
 EOF
+}
+
+amp_helper_path() {
+  printf '%s\n' "$app_path/Contents/Helpers/$amp_app_name.app"
+}
+
+validate_app_bundle() {
+  local bundle="$1"
+  if [[ ! -d "$bundle" ]]; then
+    echo "App bundle not found: $bundle" >&2
+    exit 66
+  fi
+
+  if [[ ! -f "$bundle/Contents/Info.plist" ]]; then
+    echo "That does not look like a macOS .app bundle: $bundle" >&2
+    exit 65
+  fi
+}
+
+install_amp_helper() {
+  local helper_path
+  helper_path="$(amp_helper_path)"
+  echo "Embedding $amp_app_path in $helper_path"
+  rm -rf "$helper_path"
+  mkdir -p "$(dirname "$helper_path")"
+  ditto "$amp_app_path" "$helper_path"
+  validate_app_bundle "$helper_path"
+}
+
+sign_app_bundle() {
+  local bundle="$1"
+  echo "Signing $bundle"
+  codesign --force --deep --options runtime --timestamp --sign "$sign_identity" "$bundle"
+  codesign --verify --deep --strict --verbose=2 "$bundle"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -152,27 +187,16 @@ if [[ "$build_app" == true ]]; then
     POMO_SUPPORT_DIR="${POMO_AMP_SUPPORT_DIR:-Pomo Amp}" \
     POMO_URL_SCHEME="${POMO_AMP_URL_SCHEME:-pomo-amp}" \
     "$repo_root/scripts/run-app.sh" --amp "${run_args[@]}"
-elif [[ "$skip_sign" != "1" ]]; then
-  echo "Signing $app_path"
-  codesign --force --deep --options runtime --timestamp --sign "$sign_identity" "$app_path"
-  codesign --verify --deep --strict --verbose=2 "$app_path"
-
-  echo "Signing $amp_app_path"
-  codesign --force --deep --options runtime --timestamp --sign "$sign_identity" "$amp_app_path"
-  codesign --verify --deep --strict --verbose=2 "$amp_app_path"
 fi
 
-for bundle in "$app_path" "$amp_app_path"; do
-  if [[ ! -d "$bundle" ]]; then
-    echo "App bundle not found: $bundle" >&2
-    exit 66
-  fi
+validate_app_bundle "$app_path"
+validate_app_bundle "$amp_app_path"
+install_amp_helper
 
-  if [[ ! -f "$bundle/Contents/Info.plist" ]]; then
-    echo "That does not look like a macOS .app bundle: $bundle" >&2
-    exit 65
-  fi
-done
+if [[ "$skip_sign" != "1" ]]; then
+  sign_app_bundle "$(amp_helper_path)"
+  sign_app_bundle "$app_path"
+fi
 
 mkdir -p "$(dirname "$dmg_path")" "$repo_root/dist"
 staging_dir="$(mktemp -d "$repo_root/dist/dmg-staging.XXXXXXXX")"
@@ -183,7 +207,6 @@ trap cleanup EXIT
 
 echo "Packaging $dmg_path"
 ditto "$app_path" "$staging_dir/$app_name.app"
-ditto "$amp_app_path" "$staging_dir/$amp_app_name.app"
 ln -s /Applications "$staging_dir/Applications"
 
 rm -f "$dmg_path"

--- a/apps/tauri/landing/app/home-content.tsx
+++ b/apps/tauri/landing/app/home-content.tsx
@@ -144,7 +144,7 @@ function Nav() {
           <a href="#stats" style={link}><span style={{ color: "#6b6055" }}>:</span>stats</a>
         </nav>
         <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
-          <span style={{ fontFamily: mono, fontSize: 11, color: "#6b6055", letterSpacing: "0.06em" }}>v0.2.7 · macOS</span>
+          <span style={{ fontFamily: mono, fontSize: 11, color: "#6b6055", letterSpacing: "0.06em" }}>v0.2.8 · macOS</span>
           <a
             href={DOWNLOAD_URL}
             style={{
@@ -903,7 +903,7 @@ function DownloadCTA() {
             >
               View source
             </a>
-            <span style={{ fontFamily: mono, fontSize: 11, letterSpacing: "0.06em", color: "#6b6055" }}>v0.2.7 · macOS 14+</span>
+            <span style={{ fontFamily: mono, fontSize: 11, letterSpacing: "0.06em", color: "#6b6055" }}>v0.2.8 · macOS 14+</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Updates the Pomo/Pomo Amp menubar presentation so Amp uses the shared clock-style icon without the text label, adds playback state indication, and keeps the compact HUD link visually attached in the top-right position.
- Ports the previously solved Pomo cookie-import flow into the current shared Amp path: account picker plumbing, preserved HttpOnly cookies, restore-before-navigation, strict auth-cookie persistence, and a Google ServiceLogin bounce so imported YouTube cookies actually register in WebKit.
- Fixes audio visualizer permission targeting/smoothing and updates release/build packaging docs and scripts so the embedded Amp helper is built and installed consistently.
- Bumps the landing page release label to `v0.2.8` for the patch release.

## Root Cause

The installed menubar helper could lag the dev build, and Amp’s cookie import was setting browser cookies but then navigating directly to YouTube. WebKit/YouTube could see the cookie transfer but still hydrate as signed out until Google’s login flow bound the session inside the WebView. The import command path also dropped the selected account index.

## Validation

- `git diff --check`
- `swift build --product PomoAmp`
- `swift build --product Pomo`
- Signed and replaced `/Applications/Pomo.app/Contents/Helpers/Pomo Amp.app`
- `codesign --verify --deep --strict /Applications/Pomo.app`
- Runtime smoke: `pomo-amp://login/import?browser=chrome&profile=Profile%203&account=0` ended with `account:1` in `/tmp/pomo-webaudio.log` after the Google login bounce.