### PR TITLE
Add tiny HUD mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ are in [`apps/macos/README.md`](apps/macos/README.md).
 
 Control and install Pomo from the shell or an agent. Live ANSI terminal UI,
 `pomo://` commands, and JSON state reads. Published independently of the macOS
-app — see **`cli-v*`** tags for npm releases (currently **0.3.6** in tree;
+app — see **`cli-v*`** tags for npm releases (currently **0.3.7** in tree;
 registry may be ahead until the next tag publish).
 
 ```sh
@@ -92,8 +92,8 @@ Two release lines share this repo:
 
 | Line | Tag format | Current | Ships |
 | --- | --- | --- | --- |
-| macOS app | `v*` | `v0.2.8` | `Pomo.dmg` via GitHub Releases |
-| npm CLI | `cli-v*` | `cli-v0.3.6` (next) | `@arach/pomo` on npm |
+| macOS app | `v*` | `v0.2.9` | `Pomo.dmg` via GitHub Releases |
+| npm CLI | `cli-v*` | `cli-v0.3.7` | `@arach/pomo` on npm |
 
 Keep `apps/cli/package.json` in sync with the latest npm publish before cutting
 the next `cli-v*` tag.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -86,7 +86,7 @@ Video      video <show|hide|toggle|page|player|browser>
 Favorites  fav · fav add <url> [title…] · fav rename <n> <title…>
            fav url <n> <url> · fav move <from> <to>
            fav set <json-file|json|-> · fav play <n> · fav remove <n> · fav clear
-Window     show · hide · hud · menu · face <name> · settings · stats
+Window     show · hide · hud · tiny · hud <tiny|full> · menu · face <name> · settings · stats
 Login      login · login import [--browser b] [--profile p] · login profiles
            login account <n> · logout
 App        install [--dry-run] [--open] · quit

--- a/apps/cli/bin/pomo.js
+++ b/apps/cli/bin/pomo.js
@@ -127,7 +127,7 @@ function printStatus(args) {
   }
   console.log(`  audio   ${audio}`);
   console.log(`  today   ${s.focusToday ?? 0} focus · streak ${s.streakDays ?? 0}d · ${s.focusTotal ?? 0} total`);
-  console.log(`  hud     ${s.hudVisible ? 'visible' : 'hidden'} · face ${s.watchface}`);
+  console.log(`  hud     ${s.hudVisible ? 'visible' : 'hidden'} · ${s.hudMode || 'full'} · face ${s.watchface}`);
 
   const favs = s.favorites || [];
   const sessionAudio = s.sessionAudioURLs || {};
@@ -1654,7 +1654,7 @@ function buildDashboardLayout(s, edit, template, themeId, width, celebrate, tick
     c, frame, inner, progress, pct, phase, session, roundNum, audio, whisper, clock, align,
   } = ctx;
   const stats = `${s.focusToday ?? 0} today · ${s.streakDays ?? 0}d streak · ${s.focusTotal ?? 0} all`;
-  const hud = `${s.hudVisible ? 'on' : 'off'} · ${titleCase(s.watchface)}`;
+  const hud = `${s.hudVisible ? 'on' : 'off'} · ${s.hudMode || 'full'} · ${titleCase(s.watchface)}`;
   const header = splitRow(
     `${c.accent}${c.b}${c.mark} POMO${c.t}`,
     `${c.mute}${template.label}${c.t} · ${c.label}${c.t}`,
@@ -2366,7 +2366,7 @@ function buildStatsCard(s, templateId, themeId, width, celebrate, tick) {
     boxRow(statRow('session', `${sessionLabel(s.sessionType)} · ${s.phase || 'idle'}`, c, inner), width, frame, c, celebrate, tick),
     boxRow(statRow('clock', `${s.clock || '--:--'} (${pct}%)`, c, inner), width, frame, c, celebrate, tick),
     boxRow(statRow('elapsed', `${formatClock(elapsed)} / ${formatClock(s.totalSeconds)}`, c, inner), width, frame, c, celebrate, tick),
-    boxRow(statRow('hud', `${s.hudVisible ? 'visible' : 'hidden'} · ${titleCase(s.watchface)}`, c, inner), width, frame, c, celebrate, tick),
+    boxRow(statRow('hud', `${s.hudVisible ? 'visible' : 'hidden'} · ${s.hudMode || 'full'} · ${titleCase(s.watchface)}`, c, inner), width, frame, c, celebrate, tick),
     boxRow(statRow('audio', truncate(audioLine(s, celebrate, tick), inner - 8), c, inner), width, frame, c, celebrate, tick),
     boxRow('', width, frame, c, celebrate, tick),
     boxRow(centerRow(`${c.dim}4 or esc close${c.t}`, inner), width, frame, c, celebrate, tick),
@@ -3077,6 +3077,8 @@ Favorites
 
 Window & app
   show | hide | hud      summon / dismiss / toggle the HUD
+  tiny                   show the HUD in tiny corner mode
+  hud tiny|full          switch HUD size
   menu                   open the menu-bar popover
   face <name>            switch watchface
   settings | stats       open the Settings / Stats window
@@ -3116,7 +3118,14 @@ switch (cmd) {
     break;
 
   case 'hud':
-    send('hud');
+    if (rest[0] === 'tiny' || rest[0] === 'mini' || rest[0] === 'small') send('hud/tiny');
+    else if (rest[0] === 'full' || rest[0] === 'normal') send('hud/full');
+    else if (rest[0]) die('usage: pomo hud [tiny|full]');
+    else send('hud');
+    break;
+
+  case 'tiny':
+    send('hud/tiny');
     break;
 
   case 'session':

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arach/pomo",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Control and install the Pomo macOS HUD timer from the shell or an agent — live ANSI terminal UI, pomo:// commands, and JSON state reads. Zero dependencies.",
   "type": "module",
   "bin": {

--- a/apps/macos/Sources/PomoShared/AppDelegate.swift
+++ b/apps/macos/Sources/PomoShared/AppDelegate.swift
@@ -68,7 +68,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         settings.onChange = { [weak self] in
             guard let self else { return }
             self.model.reloadDurationsIfIdle()
-            self.hud.applyOpacity()
+            self.hud.applyPresentationSettings()
             self.menuBar.refresh()
             self.registerSummonHotkey()
             self.audio.setVolume(self.settings.audioVolume)
@@ -223,6 +223,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         case .showHUD:     hud.show()
         case .hideHUD:     hud.hide()
         case .toggleHUD:   hud.toggle()
+        case .hudTiny(let tiny):
+            if let tiny { hud.setTinyMode(tiny) }
+            else { hud.toggleTinyMode() }
+            hud.show()
         case .session(let type): model.setSessionType(type)
         case .duration(let minutes): model.setMinutes(minutes)
         case .face(let face):
@@ -386,6 +390,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             intent: model.intent,
             watchface: settings.watchface.rawValue,
             hudVisible: hud.isShown,
+            hudMode: hud.chrome.isTiny ? "tiny" : "full",
             audioPlaying: audio.isPlaying,
             audioURL: preferredAudioURL(),
             audioEngine: audio.engineName,

--- a/apps/macos/Sources/PomoShared/Control/AgentControl.swift
+++ b/apps/macos/Sources/PomoShared/Control/AgentControl.swift
@@ -6,6 +6,7 @@ import Foundation
 enum PomoCommand {
     case start, pause, toggle, reset, skip
     case showHUD, hideHUD, toggleHUD
+    case hudTiny(Bool?)        // nil toggles tiny/full; true = tiny; false = full
     case session(SessionType)
     case face(Watchface)
     case duration(Int)
@@ -61,7 +62,17 @@ enum PomoCommand {
         case "skip":       self = .skip
         case "show":       self = .showHUD
         case "hide":       self = .hideHUD
-        case "toggle-hud", "togglehud", "hud": self = .toggleHUD
+        case "tiny", "tiny-hud", "mini", "mini-hud": self = .hudTiny(true)
+        case "full", "full-hud", "big-hud": self = .hudTiny(false)
+        case "toggle-hud", "togglehud": self = .toggleHUD
+        case "hud":
+            switch arg {
+            case "tiny", "mini", "small": self = .hudTiny(true)
+            case "full", "normal", "large": self = .hudTiny(false)
+            case "mode", "size": self = .hudTiny(nil)
+            case "toggle", nil: self = .toggleHUD
+            default: return nil
+            }
         case "menu":       self = .openMenu
         case "shortcuts", "help", "keys":
             switch arg {
@@ -236,6 +247,7 @@ struct PomoState: Codable {
     var intent: String
     var watchface: String
     var hudVisible: Bool
+    var hudMode: String
     var audioPlaying: Bool
     var audioURL: String
     var audioEngine: String   // "web" | "none"

--- a/apps/macos/Sources/PomoShared/Core/PomoSettings.swift
+++ b/apps/macos/Sources/PomoShared/Core/PomoSettings.swift
@@ -31,6 +31,8 @@ final class PomoSettings {
     // Independent of `panelOpacity` so a see-through panel can still read as
     // frosted glass.
     var backgroundBlur: Double = 1.0
+    // Persisted presentation mode for a small always-visible corner HUD.
+    var hudTinyMode: Bool = false
 
     // Sound
     var soundEnabled: Bool = true
@@ -203,6 +205,7 @@ final class PomoSettings {
         var pomoAmpVisualizerMode: PomoAmpVisualizerMode?
         var panelOpacity: Double
         var backgroundBlur: Double?
+        var hudTinyMode: Bool?
         var soundEnabled: Bool
         var volume: Double
         // Optional so settings files written before these fields still decode.
@@ -231,6 +234,7 @@ final class PomoSettings {
             pomoAmpVisualizerMode: pomoAmpVisualizerMode,
             panelOpacity: panelOpacity,
             backgroundBlur: backgroundBlur,
+            hudTinyMode: hudTinyMode,
             soundEnabled: soundEnabled,
             volume: volume,
             appearanceMode: appearanceMode,
@@ -259,6 +263,7 @@ final class PomoSettings {
         if let mode = dto.appearanceMode { appearanceMode = mode }
         panelOpacity = min(1.0, max(0.3, dto.panelOpacity))
         if let blur = dto.backgroundBlur { backgroundBlur = min(1.0, max(0.0, blur)) }
+        if let tiny = dto.hudTinyMode { hudTinyMode = tiny }
         soundEnabled = dto.soundEnabled
         volume = min(1.0, max(0.0, dto.volume))
         if let code = dto.hotkeyKeyCode { hotkeyKeyCode = code }
@@ -299,9 +304,8 @@ final class PomoSettings {
     }
 }
 
-/// How the adaptive app windows (Settings) choose their light/dark palette.
-/// The HUD, menu popover, and Stats are deliberately fixed-dark glass, so this
-/// only affects the windows that sit against the desktop via `AppPalette`.
+/// How adaptive surfaces (Settings, the menu popover, and tiny HUD) choose their
+/// light/dark palette. The full watchface HUD remains fixed-dark glass.
 enum AppearanceMode: String, Codable, CaseIterable, Identifiable {
     case system, light, dark
 

--- a/apps/macos/Sources/PomoShared/HUD/HUDController.swift
+++ b/apps/macos/Sources/PomoShared/HUD/HUDController.swift
@@ -3,11 +3,18 @@ import Observation
 import SwiftUI
 
 /// HUD-only presentation chrome the SwiftUI content reacts to but the AppKit key
-/// monitor drives — currently just the keyboard cheat sheet toggled with `?`.
+/// monitor drives: keyboard cheat sheet, tiny/full mode, and live panel size.
 @MainActor
 @Observable
 final class HUDChrome {
     var showShortcuts = false
+    var isTiny: Bool
+    var panelSize: CGSize
+
+    init(panelSize: CGSize, isTiny: Bool = false) {
+        self.panelSize = panelSize
+        self.isTiny = isTiny
+    }
 }
 
 /// Owns the floating HUD panel: lazy construction, summon/dismiss with a fade,
@@ -15,6 +22,11 @@ final class HUDChrome {
 /// shortcuts that are live only while the HUD is visible.
 @MainActor
 final class HUDController {
+    private static let fullContentSize = NSSize(width: 352, height: 268)
+    private static let tinyContentSize = NSSize(width: 188, height: 86)
+    private static let fullSavedPanelFrameKey = "pomo.hud.panelFrame.full"
+    private static let tinySavedPanelFrameKey = "pomo.hud.panelFrame.tiny"
+
     private let model: TimerModel
     private let settings: PomoSettings
     private let audio: AudioController
@@ -32,13 +44,12 @@ final class HUDController {
     /// ⌘-Tab-able — dropping back to a menu-bar accessory when hidden).
     var onVisibilityChange: ((Bool) -> Void)?
 
-    /// HUD-only chrome (keyboard cheat sheet) shared with the SwiftUI content.
-    let chrome = HUDChrome()
+    /// HUD-only chrome shared with the SwiftUI content.
+    let chrome: HUDChrome
 
-    private let contentSize = NSSize(width: 352, height: 268)
     private var panel: HUDPanel?
     private var keyMonitor: Any?
-    private var hasPositioned = false
+    private var panelFrameObserverTokens: [NSObjectProtocol] = []
     private(set) var isShown = false
 
     init(model: TimerModel, settings: PomoSettings, audio: AudioController, favorites: FavoritesStore) {
@@ -46,13 +57,19 @@ final class HUDController {
         self.settings = settings
         self.audio = audio
         self.favorites = favorites
+        self.chrome = HUDChrome(
+            panelSize: settings.hudTinyMode ? Self.tinyContentSize : Self.fullContentSize,
+            isTiny: settings.hudTinyMode
+        )
     }
 
     // MARK: - Panel lifecycle
 
     private func ensurePanel() -> HUDPanel {
         if let panel { return panel }
-        let panel = HUDPanel(contentSize: contentSize)
+        let initialSize = effectivePanelSize()
+        chrome.panelSize = initialSize
+        let panel = HUDPanel(contentSize: initialSize)
         panel.onKeyDown = { [weak self] event in
             self?.handle(event) ?? false
         }
@@ -60,15 +77,23 @@ final class HUDController {
             rootView: HUDRootView(
                 model: model, settings: settings, audio: audio, favorites: favorites,
                 chrome: chrome,
-                size: contentSize,
                 onHide: { [weak self] in self?.hide() },
+                onSetTinyMode: { [weak self] tiny in self?.setTinyMode(tiny) },
                 onToggleVideoDrawer: { [weak self] in self?.toggleVideoDrawer() },
                 onEditingChange: { [weak self] editing in self?.setEditingFocus(editing) }
             )
         )
-        hosting.frame = NSRect(origin: .zero, size: contentSize)
+        hosting.frame = NSRect(origin: .zero, size: initialSize)
         hosting.autoresizingMask = [.width, .height]
         panel.contentView = hosting
+        if let restored = restoredPanelFrame(size: initialSize, for: panel, tiny: chrome.isTiny) {
+            panel.setFrame(restored, display: false)
+        } else {
+            positionOnActiveScreen(panel)
+            savePanelFrame(panel.frame, tiny: chrome.isTiny)
+        }
+        installPanelFrameObservers(panel)
+        panel.alphaValue = CGFloat(settings.panelOpacity)
         self.panel = panel
         return panel
     }
@@ -81,10 +106,8 @@ final class HUDController {
 
     func show() {
         let panel = ensurePanel()
-        if !hasPositioned {
-            positionOnActiveScreen(panel)
-            hasPositioned = true
-        }
+        applyPresentationSettings()
+        keepPanelVisible(panel)
         isShown = true
         installKeyMonitor()
 
@@ -97,7 +120,11 @@ final class HUDController {
             panel.animator().alphaValue = CGFloat(settings.panelOpacity)
         }
         // Dock the video drawer to the panel (slides back out if it was open).
-        audio.attachDrawer(to: panel)
+        if chrome.isTiny {
+            audio.detachDrawer()
+        } else {
+            audio.attachDrawer(to: panel)
+        }
         onVisibilityChange?(true)
     }
 
@@ -125,6 +152,20 @@ final class HUDController {
         panel.alphaValue = CGFloat(settings.panelOpacity)
     }
 
+    /// Keep mode + opacity in sync with persisted settings edits.
+    func applyPresentationSettings() {
+        setTinyMode(settings.hudTinyMode, persist: false)
+        applyOpacity()
+    }
+
+    func toggleTinyMode() {
+        setTinyMode(!chrome.isTiny)
+    }
+
+    func setTinyMode(_ tiny: Bool) {
+        setTinyMode(tiny, persist: true)
+    }
+
     /// While a quick field is open, ramp the panel to full opacity so the editor
     /// card is crisp; restore the user's opacity when it closes.
     private func setEditingFocus(_ editing: Bool) {
@@ -134,6 +175,101 @@ final class HUDController {
             ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
             panel.animator().alphaValue = editing ? 1.0 : CGFloat(settings.panelOpacity)
         }
+    }
+
+    private func setTinyMode(_ tiny: Bool, persist: Bool) {
+        if chrome.isTiny == tiny {
+            if persist, settings.hudTinyMode != tiny {
+                settings.hudTinyMode = tiny
+                settings.saveNow()
+            }
+            return
+        }
+
+        if let panel {
+            savePanelFrame(panel.frame, tiny: chrome.isTiny)
+        }
+
+        chrome.isTiny = tiny
+        chrome.panelSize = effectivePanelSize()
+
+        if tiny {
+            chrome.showShortcuts = false
+            model.cancelEditing()
+            audio.detachDrawer()
+        }
+
+        if persist, settings.hudTinyMode != tiny {
+            settings.hudTinyMode = tiny
+            settings.saveNow()
+        }
+
+        guard let panel else { return }
+        let size = effectivePanelSize()
+        let old = panel.frame
+        let fallback: NSRect
+        if tiny {
+            fallback = NSRect(x: old.maxX - size.width, y: old.maxY - size.height, width: size.width, height: size.height)
+        } else {
+            fallback = NSRect(x: old.midX - size.width / 2, y: old.midY - size.height / 2, width: size.width, height: size.height)
+        }
+        let target = restoredPanelFrame(size: size, for: panel, tiny: tiny)
+            ?? clampedFrame(fallback, for: panel)
+
+        panel.contentView?.setFrameSize(size)
+        panel.setFrame(target, display: true)
+        savePanelFrame(target, tiny: tiny)
+
+        if isShown, !tiny {
+            audio.attachDrawer(to: panel)
+        }
+    }
+
+    private func effectivePanelSize() -> NSSize {
+        chrome.isTiny ? Self.tinyContentSize : Self.fullContentSize
+    }
+
+    private func installPanelFrameObservers(_ panel: NSPanel) {
+        let center = NotificationCenter.default
+        panelFrameObserverTokens.forEach(center.removeObserver)
+        panelFrameObserverTokens = [
+            center.addObserver(forName: NSWindow.didMoveNotification, object: panel, queue: .main) { [weak self, weak panel] _ in
+                guard let panel else { return }
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.savePanelFrame(panel.frame, tiny: self.chrome.isTiny)
+                }
+            },
+            center.addObserver(forName: NSWindow.didResizeNotification, object: panel, queue: .main) { [weak self, weak panel] _ in
+                guard let panel else { return }
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.savePanelFrame(panel.frame, tiny: self.chrome.isTiny)
+                }
+            }
+        ]
+    }
+
+    private func restoredPanelFrame(size: NSSize, for panel: NSPanel, tiny: Bool) -> NSRect? {
+        guard let raw = UserDefaults.standard.string(forKey: savedPanelFrameKey(tiny: tiny)) else { return nil }
+        let saved = NSRectFromString(raw)
+        guard saved.width > 1, saved.height > 1 else { return nil }
+        let target = NSRect(
+            x: saved.minX,
+            y: saved.maxY - size.height,
+            width: size.width,
+            height: size.height
+        )
+        return clampedFrame(target, for: panel)
+    }
+
+    private func savePanelFrame(_ frame: NSRect, tiny: Bool) {
+        guard frame.width > 1, frame.height > 1 else { return }
+        UserDefaults.standard.set(NSStringFromRect(frame), forKey: savedPanelFrameKey(tiny: tiny))
+    }
+
+    private func savedPanelFrameKey(tiny: Bool) -> String {
+        tiny ? Self.tinySavedPanelFrameKey : Self.fullSavedPanelFrameKey
     }
 
     private func positionOnActiveScreen(_ panel: NSPanel) {
@@ -146,6 +282,55 @@ final class HUDController {
         let x = frame.midX - size.width / 2
         let y = frame.midY - size.height / 2 + frame.height * 0.06
         panel.setFrameOrigin(NSPoint(x: x.rounded(), y: y.rounded()))
+    }
+
+    private func keepPanelVisible(_ panel: NSPanel) {
+        let frame = panel.frame
+        let clamped = clampedFrame(frame, for: panel)
+        if clamped != frame {
+            panel.setFrame(clamped, display: false)
+            savePanelFrame(clamped, tiny: chrome.isTiny)
+        }
+    }
+
+    private func clampedFrame(_ frame: NSRect, for panel: NSPanel) -> NSRect {
+        let bounds = bestScreen(for: frame, fallback: panel)?.visibleFrame ?? frame
+        var frame = frame
+        frame.size.width = min(frame.width, bounds.width)
+        frame.size.height = min(frame.height, bounds.height)
+        if frame.minX < bounds.minX { frame.origin.x = bounds.minX }
+        if frame.maxX > bounds.maxX { frame.origin.x = bounds.maxX - frame.width }
+        if frame.minY < bounds.minY { frame.origin.y = bounds.minY }
+        if frame.maxY > bounds.maxY { frame.origin.y = bounds.maxY - frame.height }
+        return frame
+    }
+
+    private func bestScreen(for frame: NSRect, fallback panel: NSPanel) -> NSScreen? {
+        let screens = NSScreen.screens
+        let best = screens
+            .map { screen in (screen, intersectionArea(screen.visibleFrame, frame)) }
+            .max { lhs, rhs in lhs.1 < rhs.1 }
+        if let best, best.1 > 0 { return best.0 }
+
+        let center = NSPoint(x: frame.midX, y: frame.midY)
+        let nearest = screens.min { lhs, rhs in
+            distance(from: center, to: lhs.visibleFrame) < distance(from: center, to: rhs.visibleFrame)
+        }
+        if let nearest { return nearest }
+
+        return panel.screen ?? NSScreen.main ?? NSScreen.screens.first
+    }
+
+    private func intersectionArea(_ lhs: NSRect, _ rhs: NSRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull else { return 0 }
+        return intersection.width * intersection.height
+    }
+
+    private func distance(from point: NSPoint, to rect: NSRect) -> CGFloat {
+        let dx = max(rect.minX - point.x, 0, point.x - rect.maxX)
+        let dy = max(rect.minY - point.y, 0, point.y - rect.maxY)
+        return hypot(dx, dy)
     }
 
     // MARK: - In-panel keyboard shortcuts
@@ -215,13 +400,23 @@ final class HUDController {
         case "r": model.reset(); return true
         case "n": model.skip(); return true
         case "c": model.cycleSessionType(); return true
-        case "i": model.beginEditing(.intent); return true
+        case "i":
+            if chrome.isTiny { setTinyMode(false) }
+            model.beginEditing(.intent)
+            return true
         case "v":
             if shift { toggleVideoDrawer() }            // ⇧V: show / hide the video drawer
-            else { model.beginEditing(.video) }         // v: paste an audio / video link
+            else {
+                if chrome.isTiny { setTinyMode(false) }
+                model.beginEditing(.video)              // v: paste an audio / video link
+            }
             return true
         case "m": toggleMusic(); return true            // play/pause background music
-        case "?", "/": chrome.showShortcuts.toggle(); return true  // keyboard cheat sheet
+        case "y": toggleTinyMode(); return true         // tiny/full HUD
+        case "?", "/":
+            if chrome.isTiny { setTinyMode(false) }
+            chrome.showShortcuts.toggle()
+            return true                                 // keyboard cheat sheet
         case "q": hide(); return true
         case "t":
             settings.watchface = settings.watchface.next
@@ -249,6 +444,7 @@ final class HUDController {
     /// is loaded yet, kick off the saved station so the drawer has something to show.
     private func toggleVideoDrawer() {
         if onVideoCommand?(.videoToggle) == true { return }
+        if chrome.isTiny { setTinyMode(false) }
         if !audio.videoVisible, !audio.isPlaying, audio.currentURL.isEmpty, !settings.audioURL.isEmpty {
             audio.play(urlString: settings.audioURL)
         }

--- a/apps/macos/Sources/PomoShared/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/PomoShared/HUD/HUDRootView.swift
@@ -13,9 +13,9 @@ struct HUDRootView: View {
     let favorites: FavoritesStore
     /// Shared HUD chrome (keyboard cheat sheet), driven by HUDController's key monitor.
     let chrome: HUDChrome
-    let size: CGSize
     /// Dismiss the HUD (right-click → Hide). Wired by HUDController.
     var onHide: (() -> Void)? = nil
+    var onSetTinyMode: ((Bool) -> Void)? = nil
     var onToggleVideoDrawer: (() -> Void)? = nil
     /// Editing a quick field → make the panel fully opaque so the card is crisp
     /// rather than bleeding the face + desktop through the panel's translucency.
@@ -51,14 +51,15 @@ struct HUDRootView: View {
     // The Blueprint face reads as a drafting sheet, so it wants hard, near-square
     // corners; every other face keeps the soft frosted-HUD radius.
     private var baseRadius: CGFloat {
-        settings.watchface == .blueprint ? 0 : 12
+        if chrome.isTiny { return 10 }
+        return settings.watchface == .blueprint ? 0 : 12
     }
 
     // When the video drawer is docked, square the two corners on its side so the
     // HUD and drawer read as one continuous block rather than two cards kissing.
     private var cornerRadii: RectangleCornerRadii {
         let r = baseRadius
-        guard audio.videoOpen, settings.watchface != .blueprint else {
+        guard !chrome.isTiny, audio.videoOpen, settings.watchface != .blueprint else {
             return RectangleCornerRadii(topLeading: r, bottomLeading: r, bottomTrailing: r, topTrailing: r)
         }
         switch audio.videoEdge {
@@ -74,6 +75,43 @@ struct HUDRootView: View {
     }
 
     var body: some View {
+        hudContent
+        .animation(.easeOut(duration: 0.12), value: chrome.showShortcuts)
+        .animation(.easeOut(duration: 0.16), value: chrome.isTiny)
+        .frame(width: chrome.panelSize.width, height: chrome.panelSize.height)
+        .clipShape(panelShape)
+        .overlay(
+            panelShape
+                .stroke(Color.white.opacity(0.10), lineWidth: 1)
+        )
+        .overlay(
+            panelShape
+                .stroke(Color.black.opacity(0.35), lineWidth: 1)
+                .blendMode(.plusDarker)
+                .padding(0.5)
+        )
+        // Panel-level opacity is applied to the window's alphaValue by
+        // HUDController (so it composes with the summon/dismiss fade).
+        .environment(\.hudTheme, .default)
+        .environment(\.audioControls, audioFaceControls)
+        // Right-click anywhere on the HUD for the quick-entry actions.
+        .contextMenu { hudContextMenu }
+    }
+
+    @ViewBuilder
+    private var hudContent: some View {
+        if chrome.isTiny {
+            TinyHUDView(
+                model: model,
+                settings: settings,
+                onExpand: { onSetTinyMode?(false) }
+            )
+        } else {
+            fullHUDContent
+        }
+    }
+
+    private var fullHUDContent: some View {
         ZStack {
             // Tunable backdrop blur of the desktop behind the panel — true
             // CSS-`backdrop-filter` semantics: it softens the layer *behind*,
@@ -111,25 +149,6 @@ struct HUDRootView: View {
                     .transition(.opacity)
             }
         }
-        .animation(.easeOut(duration: 0.12), value: chrome.showShortcuts)
-        .frame(width: size.width, height: size.height)
-        .clipShape(panelShape)
-        .overlay(
-            panelShape
-                .stroke(Color.white.opacity(0.10), lineWidth: 1)
-        )
-        .overlay(
-            panelShape
-                .stroke(Color.black.opacity(0.35), lineWidth: 1)
-                .blendMode(.plusDarker)
-                .padding(0.5)
-        )
-        // Panel-level opacity is applied to the window's alphaValue by
-        // HUDController (so it composes with the summon/dismiss fade).
-        .environment(\.hudTheme, .default)
-        .environment(\.audioControls, audioFaceControls)
-        // Right-click anywhere on the HUD for the quick-entry actions.
-        .contextMenu { hudContextMenu }
     }
 
     /// Music + video buttons docked to the panel's bottom-right corner, neutral
@@ -177,7 +196,7 @@ struct HUDRootView: View {
     private var hudContextMenu: some View {
         let hasIntent = !model.intent.isEmpty
         Button(hasIntent ? "Change Intent…" : "Set Intent…") {
-            model.beginEditing(.intent)
+            beginEditing(.intent)
         }
         if hasIntent {
             Button("Clear Intent") { model.setIntent("") }
@@ -195,11 +214,17 @@ struct HUDRootView: View {
 
         Divider()
 
-        Button("Paste Audio / Video Link…") { model.beginEditing(.video) }
+        Button("Paste Audio / Video Link…") { beginEditing(.video) }
 
         Divider()
 
-        Button("Keyboard Shortcuts") { chrome.showShortcuts = true }
+        Button(chrome.isTiny ? "Full Size HUD" : "Tiny HUD") {
+            onSetTinyMode?(!chrome.isTiny)
+        }
+        Button("Keyboard Shortcuts") {
+            if chrome.isTiny { onSetTinyMode?(false) }
+            chrome.showShortcuts = true
+        }
 
         Divider()
 
@@ -207,6 +232,554 @@ struct HUDRootView: View {
         // You can't right-click a hidden HUD, so remind them how to bring it back.
         Button("Reopen with \(settings.hotkeyDisplay)") {}
             .disabled(true)
+    }
+
+    private func beginEditing(_ field: TimerModel.QuickField) {
+        if chrome.isTiny { onSetTinyMode?(false) }
+        model.beginEditing(field)
+    }
+}
+
+/// A purpose-built small face for parking the HUD in a monitor corner. It keeps
+/// only the at-a-glance controls that survive at this size.
+private struct TinyHUDView: View {
+    let model: TimerModel
+    let settings: PomoSettings
+    var onExpand: () -> Void
+
+    @Environment(\.colorScheme) private var scheme
+
+    private var effectiveScheme: ColorScheme {
+        settings.appearanceMode.colorScheme ?? scheme
+    }
+
+    private var face: Watchface { settings.watchface }
+    private var isLight: Bool { effectiveScheme == .light }
+    private var pal: AppPalette { .resolve(effectiveScheme) }
+
+    private var accent: Color {
+        switch face {
+        case .minimal:
+            if isLight, model.sessionType == .focus { return Color(hex: 0x79720F) }
+            return model.sessionType.accentColor
+        case .terminal:
+            return Color(red: 0.35, green: 1.0, blue: 0.55)
+        case .neon:
+            return Color(red: 0.25, green: 0.95, blue: 1.0)
+        case .retroDigital:
+            return Color(red: 1.0, green: 0.78, blue: 0.18)
+        case .rolodex, .chronograph:
+            return model.sessionType.accentColor
+        case .blueprint:
+            return model.sessionType.accentColor
+        }
+    }
+
+    private var secondaryAccent: Color {
+        switch face {
+        case .neon:
+            return Color(red: 1.0, green: 0.18, blue: 0.85)
+        case .retroDigital:
+            return Color(red: 0.70, green: 0.38, blue: 0.08)
+        case .blueprint:
+            return Color(red: 0.604, green: 0.639, blue: 0.682)
+        default:
+            return accent.opacity(0.7)
+        }
+    }
+
+    private var glassGradient: [Color] {
+        switch face {
+        case .minimal:
+            return isLight
+                ? [Color.white.opacity(0.70), Color(hex: 0xEEF0F3).opacity(0.54)]
+                : [Color.black.opacity(0.34), Color.black.opacity(0.18)]
+        case .terminal:
+            return [Color.black.opacity(0.78), Color(red: 0.00, green: 0.08, blue: 0.035).opacity(0.62)]
+        case .neon:
+            return [Color(red: 0.05, green: 0.015, blue: 0.09).opacity(0.84), Color(red: 0.02, green: 0.04, blue: 0.10).opacity(0.62)]
+        case .retroDigital:
+            return [Color(red: 0.11, green: 0.075, blue: 0.025).opacity(0.86), Color.black.opacity(0.68)]
+        case .rolodex:
+            return [Color(red: 0.13, green: 0.13, blue: 0.15).opacity(0.86), Color.black.opacity(0.58)]
+        case .chronograph:
+            return [Color(white: 0.12).opacity(0.84), Color.black.opacity(0.62)]
+        case .blueprint:
+            return [Color(red: 0.102, green: 0.122, blue: 0.149).opacity(0.86), Color(red: 0.035, green: 0.047, blue: 0.063).opacity(0.70)]
+        }
+    }
+
+    private var labelColor: Color {
+        switch face {
+        case .minimal: return isLight ? pal.dim : Color.white.opacity(0.78)
+        case .terminal: return accent.opacity(0.52)
+        case .neon: return accent
+        case .retroDigital: return accent.opacity(0.66)
+        case .rolodex: return Color.white.opacity(0.62)
+        case .chronograph: return Color.white.opacity(0.66)
+        case .blueprint: return secondaryAccent
+        }
+    }
+
+    private var clockColor: Color {
+        switch face {
+        case .minimal: return isLight ? pal.ink : Color.white.opacity(0.94)
+        case .terminal: return accent
+        case .neon, .retroDigital: return accent
+        case .rolodex, .chronograph: return Color.white.opacity(0.94)
+        case .blueprint: return Color(red: 0.910, green: 0.922, blue: 0.937)
+        }
+    }
+
+    private var trackColor: Color {
+        switch face {
+        case .minimal: return isLight ? Color.black.opacity(0.11) : Color.white.opacity(0.13)
+        case .terminal: return accent.opacity(0.18)
+        case .retroDigital: return accent.opacity(0.12)
+        case .blueprint: return Color(red: 0.227, green: 0.259, blue: 0.302)
+        default: return Color.white.opacity(0.13)
+        }
+    }
+
+    private var buttonFill: Color {
+        switch face {
+        case .minimal: return isLight ? Color.white.opacity(0.66) : Color.white.opacity(0.08)
+        case .terminal: return accent.opacity(0.08)
+        case .retroDigital: return accent.opacity(0.10)
+        case .blueprint: return Color(red: 0.165, green: 0.192, blue: 0.227).opacity(0.86)
+        default: return Color.white.opacity(0.08)
+        }
+    }
+
+    private var buttonStroke: Color {
+        switch face {
+        case .minimal: return isLight ? Color.black.opacity(0.11) : Color.white.opacity(0.14)
+        case .terminal, .retroDigital, .blueprint: return accent.opacity(0.22)
+        default: return Color.white.opacity(0.14)
+        }
+    }
+
+    private var buttonIconColor: Color {
+        switch face {
+        case .minimal: return isLight ? Color.black.opacity(0.64) : Color.white.opacity(0.82)
+        case .terminal, .retroDigital, .blueprint: return accent.opacity(0.88)
+        default: return Color.white.opacity(0.82)
+        }
+    }
+
+    private var clockFont: Font {
+        switch face {
+        case .rolodex:
+            return .system(size: 30, weight: .heavy, design: .rounded)
+        case .blueprint:
+            return HudFont.mono(29, weight: .medium)
+        default:
+            return HudFont.mono(30, weight: .bold)
+        }
+    }
+
+    private var faceLabel: String {
+        switch face {
+        case .minimal: return model.sessionType.shortLabel.uppercased()
+        case .terminal: return "POMO ~/\(model.sessionType.rawValue.uppercased())"
+        case .neon: return "NEON \(model.sessionType.shortLabel.uppercased())"
+        case .retroDigital: return "LCD \(model.sessionType.shortLabel.uppercased())"
+        case .rolodex: return "FLIP \(model.sessionType.shortLabel.uppercased())"
+        case .chronograph: return "CHRONO \(model.sessionType.shortLabel.uppercased())"
+        case .blueprint: return "SHEET 01 · \(model.sessionType.shortLabel.uppercased())"
+        }
+    }
+
+    private var statusText: String {
+        switch face {
+        case .terminal:
+            if model.isRunning { return "RUN" }
+            return model.isPaused ? "PAUSE" : "IDLE"
+        case .retroDigital:
+            if model.isRunning { return "RUN" }
+            return model.isPaused ? "HOLD" : "SET"
+        case .blueprint:
+            if model.isRunning { return "RUN" }
+            return model.isPaused ? "HOLD" : "STBY"
+        case .neon:
+            if model.isRunning { return "LIVE" }
+            return model.isPaused ? "PAUSE" : "READY"
+        default:
+            if model.isRunning { return "RUN" }
+            if model.isPaused { return "PAUSE" }
+            return "READY"
+        }
+    }
+
+    private var digits: [Int] {
+        let seconds = max(0, model.remainingSeconds)
+        let minutes = min(99, seconds / 60)
+        let secs = seconds % 60
+        return [minutes / 10, minutes % 10, secs / 10, secs % 10]
+    }
+
+    var body: some View {
+        ZStack {
+            BackdropBlurView(radius: settings.backgroundBlur * 26)
+            LinearGradient(
+                colors: glassGradient,
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(Color.white.opacity(face == .minimal && isLight ? 0.48 : 0.08))
+                    .frame(height: 1)
+            }
+            faceTexture
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(accent)
+                        .frame(width: 7, height: 7)
+                        .shadow(color: accent.opacity(isLight ? 0.20 : 0.45), radius: 4)
+
+                    Text(faceLabel)
+                        .font(HudFont.mono(HudTextSize.micro, weight: .bold))
+                        .tracking(1.2)
+                        .foregroundStyle(labelColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.55)
+
+                    Text(statusText)
+                        .font(HudFont.mono(8, weight: .semibold))
+                        .tracking(1.0)
+                        .foregroundStyle(accent.opacity(0.9))
+                        .lineLimit(1)
+
+                    Spacer(minLength: 0)
+
+                    tinyIconButton(
+                        systemName: "arrow.up.left.and.arrow.down.right",
+                        help: "Full size HUD",
+                        action: onExpand
+                    )
+                }
+                .frame(height: 18)
+
+                HStack(alignment: .center, spacing: 8) {
+                    clockReadout
+                        .layoutPriority(1)
+
+                    Spacer(minLength: 0)
+
+                    tinyIconButton(
+                        systemName: model.isRunning ? "pause.fill" : "play.fill",
+                        help: model.isRunning ? "Pause" : "Start",
+                        size: 26,
+                        action: { model.toggle() }
+                    )
+                }
+                .frame(height: 34)
+
+                progressStrip
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 9)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture(count: 2, perform: onExpand)
+    }
+
+    @ViewBuilder
+    private var faceTexture: some View {
+        switch face {
+        case .terminal:
+            TinyScanlines(color: Color.black.opacity(0.28))
+        case .neon:
+            ZStack {
+                Circle()
+                    .fill(secondaryAccent.opacity(0.18))
+                    .blur(radius: 20)
+                    .offset(x: -58, y: 8)
+                Circle()
+                    .fill(accent.opacity(0.15))
+                    .blur(radius: 16)
+                    .offset(x: 62, y: -18)
+            }
+        case .retroDigital:
+            TinyScanlines(color: Color.black.opacity(0.16), step: 4)
+        case .rolodex:
+            Rectangle()
+                .fill(Color.black.opacity(0.28))
+                .frame(height: 1)
+        case .chronograph:
+            TinyChronoTexture(progress: model.progress, accent: accent)
+                .opacity(0.72)
+        case .blueprint:
+            TinyBlueprintGrid(accent: accent)
+        case .minimal:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var clockReadout: some View {
+        switch face {
+        case .retroDigital:
+            TinyLCDClock(digits: digits, on: accent, off: accent.opacity(0.11))
+                .frame(height: 31)
+                .shadow(color: accent.opacity(0.42), radius: 5)
+        case .rolodex:
+            TinyFlipClock(digits: digits)
+                .frame(height: 31)
+        default:
+            Text(model.clock)
+                .font(clockFont)
+                .foregroundStyle(clockColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.58)
+                .monospacedDigit()
+                .shadow(color: clockShadowColor, radius: clockShadowRadius)
+        }
+    }
+
+    private var clockShadowColor: Color {
+        switch face {
+        case .terminal, .retroDigital, .neon:
+            return accent.opacity(0.55)
+        default:
+            return .clear
+        }
+    }
+
+    private var clockShadowRadius: CGFloat {
+        switch face {
+        case .terminal, .retroDigital: return 5
+        case .neon: return 9
+        default: return 0
+        }
+    }
+
+    private var progressStrip: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: progressRadius, style: .continuous)
+                    .fill(trackColor)
+                RoundedRectangle(cornerRadius: progressRadius, style: .continuous)
+                    .fill(accent.opacity(0.92))
+                    .frame(width: max(0, proxy.size.width * model.progress))
+            }
+        }
+        .frame(height: 3)
+    }
+
+    private var progressRadius: CGFloat {
+        switch face {
+        case .terminal, .retroDigital, .blueprint: return 0
+        default: return 2
+        }
+    }
+
+    private func tinyIconButton(
+        systemName: String,
+        help: String,
+        size: CGFloat = 22,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: size > 22 ? 11 : 9, weight: .semibold))
+                .foregroundStyle(buttonIconColor)
+                .frame(width: size, height: size)
+                .background(Circle().fill(buttonFill))
+                .overlay(Circle().stroke(buttonStroke, lineWidth: 1))
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+}
+
+private struct TinyScanlines: View {
+    var color: Color
+    var step: CGFloat = 3
+
+    var body: some View {
+        Canvas { ctx, size in
+            var y: CGFloat = 0
+            while y < size.height {
+                ctx.fill(
+                    Path(CGRect(x: 0, y: y, width: size.width, height: 1)),
+                    with: .color(color)
+                )
+                y += step
+            }
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+private struct TinyLCDClock: View {
+    let digits: [Int]
+    let on: Color
+    let off: Color
+
+    var body: some View {
+        HStack(spacing: 3) {
+            SevenSegmentDigit(value: digits[0], on: on, off: off)
+                .frame(width: 14, height: 30)
+            SevenSegmentDigit(value: digits[1], on: on, off: off)
+                .frame(width: 14, height: 30)
+            TinySegmentColon(color: on)
+            SevenSegmentDigit(value: digits[2], on: on, off: off)
+                .frame(width: 14, height: 30)
+            SevenSegmentDigit(value: digits[3], on: on, off: off)
+                .frame(width: 14, height: 30)
+        }
+    }
+}
+
+private struct TinySegmentColon: View {
+    let color: Color
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Circle().fill(color).frame(width: 4, height: 4)
+            Circle().fill(color).frame(width: 4, height: 4)
+        }
+        .frame(width: 6, height: 28)
+        .shadow(color: color.opacity(0.5), radius: 3)
+    }
+}
+
+private struct TinyFlipClock: View {
+    let digits: [Int]
+
+    var body: some View {
+        HStack(spacing: 3) {
+            TinyFlipDigit(value: digits[0])
+            TinyFlipDigit(value: digits[1])
+            TinyFlipColon()
+            TinyFlipDigit(value: digits[2])
+            TinyFlipDigit(value: digits[3])
+        }
+    }
+}
+
+private struct TinyFlipDigit: View {
+    let value: Int
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [Color(white: 0.25), Color(white: 0.11)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+
+            Text("\(value)")
+                .font(.system(size: 22, weight: .heavy, design: .rounded))
+                .foregroundStyle(.white)
+                .monospacedDigit()
+                .id(value)
+                .transition(.push(from: .top).combined(with: .opacity))
+        }
+        .frame(width: 20, height: 30)
+        .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        .overlay(Rectangle().fill(Color.black.opacity(0.55)).frame(height: 1))
+        .overlay(RoundedRectangle(cornerRadius: 4, style: .continuous).stroke(Color.white.opacity(0.10), lineWidth: 1))
+        .animation(.snappy(duration: 0.16, extraBounce: 0.0), value: value)
+    }
+}
+
+private struct TinyFlipColon: View {
+    var body: some View {
+        VStack(spacing: 6) {
+            Circle().fill(Color.white.opacity(0.85)).frame(width: 4, height: 4)
+            Circle().fill(Color.white.opacity(0.85)).frame(width: 4, height: 4)
+        }
+        .frame(width: 5, height: 28)
+    }
+}
+
+private struct TinyChronoTexture: View {
+    let progress: Double
+    let accent: Color
+
+    var body: some View {
+        GeometryReader { geo in
+            Canvas { ctx, size in
+                let center = CGPoint(x: size.width * 0.18, y: size.height * 0.58)
+                let radius = min(size.width, size.height) * 0.38
+                for i in 0..<30 {
+                    let major = i % 5 == 0
+                    let angle = CGFloat(i) / 30 * 2 * .pi - .pi / 2
+                    let outer = CGPoint(
+                        x: center.x + cos(angle) * radius,
+                        y: center.y + sin(angle) * radius
+                    )
+                    let innerRadius = radius - (major ? 7 : 4)
+                    let inner = CGPoint(
+                        x: center.x + cos(angle) * innerRadius,
+                        y: center.y + sin(angle) * innerRadius
+                    )
+                    var path = Path()
+                    path.move(to: inner)
+                    path.addLine(to: outer)
+                    ctx.stroke(path, with: .color(.white.opacity(major ? 0.34 : 0.18)), lineWidth: major ? 1.3 : 1)
+                }
+
+                let handAngle = CGFloat(progress) * 2 * .pi - .pi / 2
+                var hand = Path()
+                hand.move(to: center)
+                hand.addLine(to: CGPoint(
+                    x: center.x + cos(handAngle) * (radius - 8),
+                    y: center.y + sin(handAngle) * (radius - 8)
+                ))
+                ctx.stroke(hand, with: .color(accent.opacity(0.78)), lineWidth: 2)
+                ctx.fill(Path(ellipseIn: CGRect(x: center.x - 3, y: center.y - 3, width: 6, height: 6)), with: .color(accent))
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+private struct TinyBlueprintGrid: View {
+    let accent: Color
+
+    var body: some View {
+        Canvas { ctx, size in
+            let grid = Color(red: 0.165, green: 0.192, blue: 0.227)
+            let line = Color(red: 0.227, green: 0.259, blue: 0.302)
+            func stroke(_ a: CGPoint, _ b: CGPoint, _ color: Color, _ width: CGFloat = 1) {
+                var path = Path()
+                path.move(to: a)
+                path.addLine(to: b)
+                ctx.stroke(path, with: .color(color), lineWidth: width)
+            }
+
+            var x: CGFloat = 0
+            var xi = 0
+            while x <= size.width {
+                stroke(CGPoint(x: x, y: 0), CGPoint(x: x, y: size.height), xi % 6 == 0 ? line.opacity(0.62) : grid.opacity(0.54))
+                x += 12
+                xi += 1
+            }
+
+            var y: CGFloat = 0
+            var yi = 0
+            while y <= size.height {
+                stroke(CGPoint(x: 0, y: y), CGPoint(x: size.width, y: y), yi % 6 == 0 ? line.opacity(0.62) : grid.opacity(0.54))
+                y += 12
+                yi += 1
+            }
+
+            let frame = CGRect(x: 6, y: 6, width: size.width - 12, height: size.height - 12)
+            ctx.stroke(Path(frame), with: .color(line.opacity(0.78)), lineWidth: 1)
+            stroke(CGPoint(x: 0, y: size.height - 12), CGPoint(x: size.width * CGFloat(0.22 + 0.74), y: size.height - 12), accent.opacity(0.55), 1.4)
+        }
+        .allowsHitTesting(false)
     }
 }
 
@@ -232,6 +805,7 @@ private struct ShortcutsOverlay: View {
         ("V", "Paste link"),
         ("⇧V", "Show/hide video"),
         ("M", "Music play/pause"),
+        ("Y", "Tiny mode"),
         ("← →", "Timestamp section"),
         ("⌘ ,", "Settings"),
         ("Esc Q", "Hide HUD"),

--- a/apps/macos/Sources/PomoShared/Settings/SettingsView.swift
+++ b/apps/macos/Sources/PomoShared/Settings/SettingsView.swift
@@ -209,6 +209,8 @@ struct SettingsView: View {
                 row("Opacity") { sliderControl(settings.binding(\.panelOpacity), range: 0.4...1.0) }
                 rowDivider
                 row("Background blur") { sliderControl(settings.binding(\.backgroundBlur), range: 0.0...1.0) }
+                rowDivider
+                row("Tiny mode") { toggle(settings.binding(\.hudTinyMode)) }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add a persisted tiny HUD mode with separate saved full/tiny panel positions.
- Render tiny HUD as a compact, face-aware corner companion for each watchface.
- Add `pomo tiny`, `pomo hud tiny`, and `pomo hud full` CLI / `pomo://` controls.
- Bump `@arach/pomo` to 0.3.7 for the npm release.

## Validation

- `swift build` from `apps/macos`
- `node --check apps/cli/bin/pomo.js`
- `npm pack --dry-run` from `apps/cli`