### PR TITLE
✨ Add SoundCloud playback and separate auth cookie jars

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arach/pomo",
-  "version": "0.3.7",
-  "description": "Control and install the Pomo macOS HUD timer from the shell or an agent — live ANSI terminal UI, pomo:// commands, and JSON state reads. Zero dependencies.",
+  "version": "0.3.8",
+  "description": "Control and install the Pomo macOS HUD timer from the shell or an agent — live ANSI terminal UI, pomo:// commands, and JSON state reads. Zero dependencies. https://pomo.arach.dev",
   "type": "module",
   "bin": {
     "pomo": "bin/pomo.js"

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -23,7 +23,10 @@ let package = Package(
                 .product(name: "HudsonUI", package: "hudsonkit-xcframework"),
                 .product(name: "HudsonShell", package: "hudsonkit-xcframework"),
             ],
-            path: "Sources/PomoShared"
+            path: "Sources/PomoShared",
+            resources: [
+                .copy("Resources/PomoAmpDefaultSkin")
+            ]
         ),
         .executableTarget(
             name: "Pomo",

--- a/apps/macos/Sources/PomoShared/AppDelegate.swift
+++ b/apps/macos/Sources/PomoShared/AppDelegate.swift
@@ -425,13 +425,17 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             settings: settings,
             favorites: favorites,
             account: audio.account,
+            soundCloudAccount: audio.soundCloudAccount,
             onClose: { [weak self] in self?.settingsWindow?.close() },
             onAudioPlay: { [weak self] url in self?.audio.play(urlString: url) },
             onAudioPause: { [weak self] in self?.audio.pause() },
             onAudioStop: { [weak self] in self?.audio.stop() },
             onSignIn: { [weak self] in self?.audio.signIn() },
             onSignOut: { [weak self] in self?.audio.clearLogin() },
-            onImportLogin: { [weak self] in self?.audio.showImportLogin() }
+            onImportLogin: { [weak self] in self?.audio.showImportLogin() },
+            onSoundCloudSignIn: { [weak self] in self?.audio.signInSoundCloud() },
+            onSoundCloudSignOut: { [weak self] in self?.audio.clearSoundCloudLogin() },
+            onSoundCloudImportLogin: { [weak self] in self?.audio.showSoundCloudImportLogin() }
         )
         let window = NSWindow(contentViewController: NSHostingController(rootView: view))
         window.title = "Pomo Settings"

--- a/apps/macos/Sources/PomoShared/Audio/AudioController.swift
+++ b/apps/macos/Sources/PomoShared/Audio/AudioController.swift
@@ -4,7 +4,7 @@ import Foundation
 import Observation
 
 /// Background audio — **browser only**. Everything (YouTube, YouTube Music,
-/// direct media URLs, pages) plays through `WebAudioPlayer`'s mini-player. No
+/// SoundCloud, direct media URLs, pages) plays through `WebAudioPlayer`'s mini-player. No
 /// yt-dlp, no native AVPlayer: the webview is the one engine, and signing in
 /// (Premium) makes it ad-free.
 ///
@@ -24,6 +24,7 @@ final class AudioController {
     private(set) var engineName = "none"   // "web" | "none" (kept in state.json)
     private(set) var currentURL = ""
     private(set) var currentTitle = ""
+    private(set) var currentArtworkURL = ""
 
     /// Whether the video drawer is open. Stored (not computed) so the on-face
     /// buttons observe it and re-render when it toggles.
@@ -64,11 +65,18 @@ final class AudioController {
     }
     func persistPlaybackSnapshot() { web.persistPlaybackSnapshotNow() }
     func signIn() { web.signIn() }
+    func signInSoundCloud() { web.signInSoundCloud() }
     func showImportLogin() { web.showImportLogin() }
+    func showSoundCloudImportLogin() { web.showSoundCloudImportLogin() }
     func importCookies(browser: String?, profile: String?, accountIndex: Int = 0) {
         web.importCookies(fromBrowser: browser, profile: profile, accountIndex: accountIndex)
     }
+    func importSoundCloudCookies(browser: String?, profile: String?) {
+        web.importSoundCloudCookies(fromBrowser: browser, profile: profile)
+    }
     func clearLogin() { web.clearLogin() }
+    func clearSoundCloudLogin() { web.clearSoundCloudLogin() }
+    var soundCloudAccount: AccountStatus { web.soundCloudAccount }
     func setAccount(_ index: Int) { web.setAccount(index) }
     func requestAudioScopePermission() { web.requestAudioScopePermission(); notify() }
     func setVisualizerActive(_ active: Bool) { web.setVisualizerActive(active); notify() }
@@ -122,6 +130,7 @@ final class AudioController {
         isPlaying = web.isPlaying
         currentURL = web.currentURL
         currentTitle = web.currentTitle
+        currentArtworkURL = web.currentArtworkURL
         engineName = web.isPlaying ? "web" : "none"
         onStateChange?()
     }

--- a/apps/macos/Sources/PomoShared/Audio/AuthService.swift
+++ b/apps/macos/Sources/PomoShared/Audio/AuthService.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// A web login surface whose cookies we back up and re-inject across launches.
+enum AuthService: String, CaseIterable {
+    case youTube
+    case soundCloud
+
+    var displayName: String {
+        switch self {
+        case .youTube: return "YouTube"
+        case .soundCloud: return "SoundCloud"
+        }
+    }
+
+    /// On-disk filename under `~/Library/Application Support/Pomo/`.
+    var cookieFileName: String {
+        switch self {
+        case .youTube: return "cookies-youtube.json"
+        case .soundCloud: return "cookies-soundcloud.json"
+        }
+    }
+
+    /// Legacy YouTube path written before service-specific jars existed.
+    var legacyCookieFileName: String? {
+        self == .youTube ? "cookies.json" : nil
+    }
+
+    var rootDomains: [String] {
+        switch self {
+        case .youTube: ["youtube.com", "google.com"]
+        case .soundCloud: ["soundcloud.com"]
+        }
+    }
+
+    var defaultContinueURL: URL {
+        switch self {
+        case .youTube: URL(string: "https://www.youtube.com/")!
+        case .soundCloud: URL(string: "https://soundcloud.com/")!
+        }
+    }
+
+    func matches(domain: String) -> Bool {
+        let normalized = domain
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+        return rootDomains.contains { root in
+            normalized == root || normalized.hasSuffix(".\(root)")
+        }
+    }
+
+    var cookieHelperFlag: String? {
+        self == .soundCloud ? "--soundcloud" : nil
+    }
+}

--- a/apps/macos/Sources/PomoShared/Audio/CookieImporter.swift
+++ b/apps/macos/Sources/PomoShared/Audio/CookieImporter.swift
@@ -21,15 +21,20 @@ enum CookieImporter {
         var subtitle: String { "\(browserName) · \(profile)" }
     }
 
-    /// Extract YouTube/Google cookies from the named browser (nil = all detected),
-    /// optionally from a specific Chromium profile (e.g. "Profile 1").
-    static func cookies(fromBrowser browser: String?, profile: String?) async -> [HTTPCookie] {
+    /// Extract auth cookies for the given service from the named browser
+    /// (nil = all detected), optionally from a specific Chromium profile.
+    static func cookies(
+        fromBrowser browser: String?,
+        profile: String?,
+        service: AuthService = .youTube
+    ) async -> [HTTPCookie] {
         guard let bin = helperPath() else { return [] }
         var args: [String] = []
+        if let flag = service.cookieHelperFlag { args.append(flag) }
         if let browser, !browser.isEmpty { args.append(browser) }
         if let profile, !profile.isEmpty { args.append(profile) }
         guard let output = await run(bin, args) else { return [] }
-        return parse(output)
+        return parse(output, service: service)
     }
 
     /// Detected Chromium-family browser profiles, matching the CLI's picker.
@@ -98,7 +103,7 @@ enum CookieImporter {
 
     // MARK: - Parse helper output (Netscape cookies.txt rows)
 
-    private static func parse(_ text: String) -> [HTTPCookie] {
+    private static func parse(_ text: String, service: AuthService) -> [HTTPCookie] {
         var cookies: [HTTPCookie] = []
         for rawLine in text.split(separator: "\n") {
             var line = String(rawLine)
@@ -127,7 +132,10 @@ enum CookieImporter {
             if secure { props[.secure] = "TRUE" }
             if httpOnly { props[HTTPCookiePropertyKey("HttpOnly")] = "TRUE" }
             if let expiry, expiry > 0 { props[.expires] = Date(timeIntervalSince1970: expiry) }
-            if let cookie = HTTPCookie(properties: props) { cookies.append(cookie) }
+            if let cookie = HTTPCookie(properties: props),
+               service.matches(domain: cookie.domain) {
+                cookies.append(cookie)
+            }
         }
         return cookies
     }

--- a/apps/macos/Sources/PomoShared/Audio/LoginPersistence.swift
+++ b/apps/macos/Sources/PomoShared/Audio/LoginPersistence.swift
@@ -1,23 +1,21 @@
 import WebKit
 
-/// On-disk backup of the YouTube/Google login cookies.
+/// On-disk backup of signed-in web-player cookies (YouTube/Google, SoundCloud).
 ///
 /// WKWebView's default data store *does* persist cookies, but it keys storage by
 /// the app's bundle id (so a dev build and the signed release don't share a
 /// login) and it drops session-only cookies between launches. We sidestep both
-/// by writing the auth cookies to `~/Library/Application Support/Pomo/cookies.json`
-/// — a path shared by every build — and re-injecting them on launch. Login is
-/// left on the drive and reloaded next time, exactly once per change.
+/// by writing auth cookies to `~/Library/Application Support/Pomo/` and
+/// re-injecting them on launch. Each service keeps its own jar so importing
+/// YouTube does not wipe SoundCloud (and vice versa).
 enum CookieJar {
-    /// Shared across bundle ids (the "Pomo" support dir is not id-scoped), so a
-    /// login made in any build is visible to the others.
-    private static let fileURL: URL = {
+    private static let supportDirectory: URL = {
         let base = FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)
             .first ?? FileManager.default.temporaryDirectory
         let dir = base.appendingPathComponent("Pomo", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir.appendingPathComponent("cookies.json")
+        return dir
     }()
 
     /// The subset of an `HTTPCookie` we need to rebuild it on the next launch.
@@ -31,10 +29,14 @@ enum CookieJar {
         let httpOnly: Bool
     }
 
-    /// Persist the given cookies (caller filters to the auth domains). Written
-    /// owner-only since these are login credentials.
-    static func save(_ cookies: [HTTPCookie]) {
-        let stored = cookies.filter { isAllowedDomain($0.domain) }.map {
+    private static func fileURL(for service: AuthService) -> URL {
+        supportDirectory.appendingPathComponent(service.cookieFileName)
+    }
+
+    /// Persist the given cookies for one service. Written owner-only since these
+    /// are login credentials.
+    static func save(_ cookies: [HTTPCookie], for service: AuthService) {
+        let stored = cookies.filter { service.matches(domain: $0.domain) }.map {
             Stored(name: $0.name, value: $0.value, domain: $0.domain, path: $0.path,
                    expires: $0.expiresDate?.timeIntervalSince1970, secure: $0.isSecure,
                    httpOnly: $0.isHTTPOnly)
@@ -42,15 +44,30 @@ enum CookieJar {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted]
         guard let data = try? encoder.encode(stored) else { return }
-        try? data.write(to: fileURL, options: .atomic)
-        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+        let url = fileURL(for: service)
+        try? data.write(to: url, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
-    /// Rebuild the saved cookies for re-injection. Expired ones are dropped.
-    static func load() -> [HTTPCookie] {
-        guard let data = try? Data(contentsOf: fileURL),
+    /// Rebuild saved cookies for one service. Expired ones are dropped.
+    static func load(for service: AuthService) -> [HTTPCookie] {
+        if let cookies = load(from: fileURL(for: service)), !cookies.isEmpty {
+            return cookies
+        }
+        if let legacy = service.legacyCookieFileName {
+            return load(from: supportDirectory.appendingPathComponent(legacy)) ?? []
+        }
+        return []
+    }
+
+    static func loadAll() -> [HTTPCookie] {
+        AuthService.allCases.flatMap { load(for: $0) }
+    }
+
+    private static func load(from url: URL) -> [HTTPCookie]? {
+        guard let data = try? Data(contentsOf: url),
               let stored = try? JSONDecoder().decode([Stored].self, from: data)
-        else { return [] }
+        else { return nil }
         let now = Date()
         return stored.compactMap { s in
             if let e = s.expires, Date(timeIntervalSince1970: e) < now { return nil }
@@ -64,12 +81,8 @@ enum CookieJar {
         }
     }
 
-    private static func isAllowedDomain(_ domain: String) -> Bool {
-        let d = domain
-            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
-            .lowercased()
-        return d == "youtube.com" || d.hasSuffix(".youtube.com")
-            || d == "google.com" || d.hasSuffix(".google.com")
+    static func service(for cookie: HTTPCookie) -> AuthService? {
+        AuthService.allCases.first { $0.matches(domain: cookie.domain) }
     }
 }
 

--- a/apps/macos/Sources/PomoShared/Audio/PlaybackSource.swift
+++ b/apps/macos/Sources/PomoShared/Audio/PlaybackSource.swift
@@ -1,0 +1,383 @@
+import Foundation
+
+/// Recognizes and normalizes background-audio URLs (YouTube, SoundCloud, …).
+enum PlaybackSource: Equatable {
+    case youTube
+    case soundCloud
+    case generic
+
+    static func detect(from raw: String) -> PlaybackSource {
+        let normalized = normalizedSource(raw)
+        let host = URLComponents(string: normalized)?.host?.lowercased() ?? ""
+        if host.contains("youtube.com") || host.contains("youtu.be") {
+            return .youTube
+        }
+        if host.contains("soundcloud.com") {
+            return .soundCloud
+        }
+        return .generic
+    }
+
+    static func isPlayable(_ raw: String) -> Bool {
+        playbackURL(from: raw, pageMode: false) != nil
+    }
+
+    /// Resolved URL to load in the web player.
+    static func playbackURL(from raw: String, pageMode: Bool) -> URL? {
+        let normalized = normalizedSource(raw)
+        if detect(from: normalized) == .soundCloud {
+            if pageMode, let canonical = soundCloudCanonicalURL(from: normalized) {
+                return URL(string: canonical)
+            }
+            return soundCloudEmbedURL(from: normalized)
+        }
+
+        let host = URLComponents(string: normalized)?.host ?? ""
+        if host.contains("music.youtube.com") { return URL(string: normalized) }
+        if let id = youTubeID(from: normalized) {
+            return URL(string: "https://www.youtube.com/watch?v=\(id)")
+        }
+        guard let url = URL(string: normalized), url.scheme != nil else { return nil }
+        return url
+    }
+
+    static func normalizedSource(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        if lower.hasPrefix("youtube.com/")
+            || lower.hasPrefix("www.youtube.com/")
+            || lower.hasPrefix("m.youtube.com/")
+            || lower.hasPrefix("music.youtube.com/")
+            || lower.hasPrefix("youtu.be/")
+            || lower.hasPrefix("soundcloud.com/")
+            || lower.hasPrefix("www.soundcloud.com/")
+            || lower.hasPrefix("on.soundcloud.com/")
+            || lower.hasPrefix("w.soundcloud.com/")
+            || lower.hasPrefix("api.soundcloud.com/") {
+            return "https://\(trimmed)"
+        }
+        return trimmed
+    }
+
+    /// Canonical SoundCloud page URL for favorites, browser hand-off, and page mode.
+    static func soundCloudCanonicalURL(from raw: String) -> String? {
+        let normalized = normalizedSource(raw)
+        guard detect(from: normalized) == .soundCloud else { return nil }
+
+        if let comps = URLComponents(string: normalized),
+           comps.host?.lowercased() == "w.soundcloud.com",
+           let encoded = comps.queryItems?.first(where: { $0.name == "url" })?.value,
+           let decoded = encoded.removingPercentEncoding?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !decoded.isEmpty {
+            if decoded.hasPrefix("http") { return decoded }
+            return "https://\(decoded)"
+        }
+
+        guard var comps = URLComponents(string: normalized) else { return nil }
+        let host = comps.host?.lowercased() ?? ""
+        guard host == "soundcloud.com"
+            || host == "www.soundcloud.com"
+            || host == "on.soundcloud.com"
+            || host == "api.soundcloud.com"
+        else { return normalized }
+
+        comps.scheme = "https"
+        if host == "www.soundcloud.com" { comps.host = "soundcloud.com" }
+        return comps.url?.absoluteString
+    }
+
+    /// Compact widget player — reliable audio in the drawer.
+    static func soundCloudEmbedURL(from raw: String) -> URL? {
+        let normalized = normalizedSource(raw)
+        guard detect(from: normalized) == .soundCloud else { return nil }
+
+        let target = soundCloudCanonicalURL(from: normalized) ?? normalized
+        var comps = URLComponents()
+        comps.scheme = "https"
+        comps.host = "w.soundcloud.com"
+        comps.path = "/player/"
+        comps.queryItems = [
+            URLQueryItem(name: "url", value: target),
+            URLQueryItem(name: "auto_play", value: "true"),
+            URLQueryItem(name: "show_artwork", value: "true"),
+            URLQueryItem(name: "show_playcount", value: "false"),
+            URLQueryItem(name: "show_teaser", value: "false"),
+            URLQueryItem(name: "visual", value: "false"),
+            URLQueryItem(name: "single_active", value: "false"),
+        ]
+        return comps.url
+    }
+
+    /// Static artwork when the live player has not reported one yet.
+    static func fallbackArtworkURL(for raw: String) -> String {
+        if let id = youTubeID(from: raw) {
+            return "https://img.youtube.com/vi/\(id)/mqdefault.jpg"
+        }
+        return ""
+    }
+
+    static func youTubeID(from string: String) -> String? {
+        let normalized = normalizedSource(string)
+        if let comps = URLComponents(string: normalized) {
+            let host = comps.host ?? ""
+            if host.contains("youtu.be") {
+                let id = comps.path.split(separator: "/").first.map(String.init)
+                if let id, isYouTubeID(id) { return id }
+            }
+            if host.contains("youtube.com") {
+                if let v = comps.queryItems?.first(where: { $0.name == "v" })?.value, isYouTubeID(v) { return v }
+                let parts = comps.path.split(separator: "/").map(String.init)
+                if let idx = parts.firstIndex(where: { ["embed", "live", "shorts", "v"].contains($0) }),
+                   idx + 1 < parts.count, isYouTubeID(parts[idx + 1]) { return parts[idx + 1] }
+            }
+        }
+        return isYouTubeID(normalized) ? normalized : nil
+    }
+
+    private static func isYouTubeID(_ s: String) -> Bool {
+        s.range(of: "^[A-Za-z0-9_-]{11}$", options: .regularExpression) != nil
+    }
+
+    static func artworkURL(for raw: String, liveArtwork: String) -> String? {
+        let live = liveArtwork.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !live.isEmpty { return live }
+        let fallback = fallbackArtworkURL(for: raw)
+        return fallback.isEmpty ? nil : fallback
+    }
+
+    static func shortLabel(for raw: String) -> String {
+        switch detect(from: raw) {
+        case .youTube:
+            if let id = youTubeID(from: raw) { return "youtube · \(id)" }
+        case .soundCloud:
+            if let path = soundCloudCanonicalURL(from: raw).flatMap(URL.init(string:))?.path,
+               !path.isEmpty, path != "/" {
+                let trimmed = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                if !trimmed.isEmpty { return "soundcloud · \(trimmed)" }
+            }
+            return "soundcloud"
+        case .generic:
+            break
+        }
+        return URLComponents(string: raw)?.host?
+            .replacingOccurrences(of: "www.", with: "") ?? raw
+    }
+
+    static func playerAttachmentJS(volume: Int, restoreSeek: Double, visualizerActive: Bool, scopeIntervalMs: Int) -> String {
+        """
+        (function(){
+          function post(m){ try{ window.webkit.messageHandlers.pomo.postMessage(m); }catch(e){} }
+          var host = (location.hostname || '').toLowerCase();
+          var isEmbed = host === 'w.soundcloud.com';
+          var isPage = host.endsWith('soundcloud.com') && !isEmbed;
+          if (!isEmbed && !isPage) return;
+
+          document.documentElement && document.documentElement.classList.add('pomo-soundcloud');
+          var __pomoRestoreSeek = \(restoreSeek);
+          var __pomoLastTitle = '';
+          var __pomoTitleTick = 0;
+
+          function cleanTitle(text){
+            text = (text || '').toString().replace(/\\s+/g, ' ').trim();
+            text = text.replace(/\\s+on SoundCloud$/i, '');
+            text = text.replace(/\\s+\\|\\s+SoundCloud$/i, '');
+            text = text.replace(/\\s+-\\s+SoundCloud$/i, '');
+            return text.trim();
+          }
+
+          function reportTitle(text){
+            text = cleanTitle(text);
+            if (!text || text === __pomoLastTitle) return;
+            __pomoLastTitle = text;
+            post('title:' + encodeURIComponent(text));
+          }
+
+          function reportArtwork(url){
+            if (!url) return;
+            post('artwork:' + encodeURIComponent(url));
+          }
+
+          function reportTitleFromDOM(){
+            var el = document.querySelector('.soundTitle__title, .soundTitle__titleText, h1.soundTitle, h1');
+            var title = el && el.textContent || '';
+            if (!title) {
+              var meta = document.querySelector('meta[property="og:title"], meta[name="title"]');
+              title = meta && meta.getAttribute('content') || document.title || '';
+            }
+            reportTitle(title);
+            var img = document.querySelector('.playbackSoundBadge__avatar img, .soundBadge__avatar img, img[src*="sndcdn.com/artworks"]');
+            if (img && img.src) reportArtwork(img.src);
+            else {
+              var art = document.querySelector('meta[property="og:image"]');
+              if (art) reportArtwork(art.getAttribute('content') || '');
+            }
+          }
+
+          function restoreSeek(v, attempts){
+            var target = Number(__pomoRestoreSeek) || 0;
+            if (target <= 1 || !v) return;
+            try {
+              var duration = Number(v.duration) || 0;
+              var clamped = duration > 2 ? Math.min(target, Math.max(0, duration - 1)) : target;
+              if (Math.abs((Number(v.currentTime) || 0) - clamped) > 1.5) v.currentTime = clamped;
+              if (duration > 0) {
+                __pomoRestoreSeek = 0;
+                post('seekrestore:' + Math.round(clamped));
+                return;
+              }
+            } catch(e) {}
+            if (attempts > 0) setTimeout(function(){ restoreSeek(v, attempts - 1); }, 450);
+          }
+
+          function attachMedia(v){
+            try { v.volume = \(volume)/100.0; } catch(e) {}
+            restoreSeek(v, 12);
+            function clock(){
+              var duration = Number(v.duration);
+              post('clock:' + JSON.stringify({
+                time: Number(v.currentTime) || 0,
+                duration: isFinite(duration) ? duration : 0,
+                paused: !!v.paused,
+                rate: Number(v.playbackRate) || 1,
+                ended: !!v.ended
+              }));
+              __pomoTitleTick += 1;
+              if (__pomoTitleTick % 4 === 0) reportTitleFromDOM();
+            }
+            v.play().then(function(){ post('playing'); }).catch(function(e){ post('playfail:' + e); });
+            if (!v.__pomo) {
+              v.__pomo = true;
+              v.addEventListener('playing', function(){ post('state:1'); });
+              v.addEventListener('pause', function(){ post('state:2'); });
+              v.addEventListener('ended', function(){ post('state:0'); });
+              v.addEventListener('seeked', clock);
+              v.addEventListener('ratechange', clock);
+              v.addEventListener('durationchange', clock);
+              v.addEventListener('timeupdate', clock);
+              v.__pomoClockTimer = setInterval(clock, 500);
+            }
+            clock();
+            reportTitleFromDOM();
+            post('attached');
+          }
+
+          function setupEmbed(attempts){
+            var media = document.querySelector('video,audio');
+            if (media) { attachMedia(media); return; }
+            var play = document.querySelector('.playControl, button.playControls__control');
+            if (play) {
+              try { play.click(); } catch(e) {}
+              post('playing');
+            }
+            reportTitleFromDOM();
+            if (attempts > 0) setTimeout(function(){ setupEmbed(attempts - 1); }, 700);
+            else post('no-video');
+          }
+
+          function bootWidget(iframe){
+            var widget = SC.Widget(iframe);
+            window.__pomoSCWidget = widget;
+            widget.bind(SC.Widget.Events.READY, function(){
+              widget.setVolume(\(volume));
+              widget.play();
+              widget.getCurrentSound(function(sound){
+                if (sound && sound.title) reportTitle(sound.title);
+                if (sound && sound.artwork_url) {
+                  reportArtwork(String(sound.artwork_url).replace('-large', '-t500x500'));
+                }
+              });
+              post('playing');
+            });
+            widget.bind(SC.Widget.Events.PLAY, function(){ post('state:1'); });
+            widget.bind(SC.Widget.Events.PAUSE, function(){ post('state:2'); });
+            widget.bind(SC.Widget.Events.FINISH, function(){ post('state:0'); });
+            widget.bind(SC.Widget.Events.PLAY_PROGRESS, function(e){
+              widget.getDuration(function(dur){
+                post('clock:' + JSON.stringify({
+                  time: (e.currentPosition || 0) / 1000,
+                  duration: (dur || 0) / 1000,
+                  paused: false,
+                  rate: 1,
+                  ended: false
+                }));
+              });
+            });
+          }
+
+          function setupPage(attempts){
+            var iframe = document.querySelector('iframe[src*="w.soundcloud.com/player"]');
+            if (!iframe) {
+              var media = document.querySelector('video,audio');
+              if (media) { attachMedia(media); return; }
+              if (attempts > 0) setTimeout(function(){ setupPage(attempts - 1); }, 700);
+              else post('no-video');
+              return;
+            }
+            function start(){
+              try { bootWidget(iframe); } catch(e) { post('playfail:' + e); }
+            }
+            if (typeof SC !== 'undefined' && SC.Widget) start();
+            else {
+              var script = document.createElement('script');
+              script.src = 'https://w.soundcloud.com/player/api.js';
+              script.onload = start;
+              script.onerror = function(){ post('playfail:widget-api'); };
+              document.head.appendChild(script);
+            }
+          }
+
+          window.__pomoVisualizerActive = \(visualizerActive ? "true" : "false");
+          window.__pomoScopeIntervalMs = \(scopeIntervalMs);
+          if (isEmbed) setupEmbed(24);
+          else if (isPage) setupPage(24);
+        })();
+        """
+    }
+
+    static let nextJS = """
+    (function(){
+      if (window.__pomoSCWidget) { window.__pomoSCWidget.next(); return; }
+      var btn = document.querySelector('.skipControl__next, button[aria-label*="Skip to next"], button[title*="Next"]');
+      if (btn) btn.click();
+    })();
+    """
+
+    static let previousJS = """
+    (function(){
+      if (window.__pomoSCWidget) { window.__pomoSCWidget.prev(); return; }
+      var btn = document.querySelector('.skipControl__previous, button[aria-label*="Skip to previous"], button[title*="Previous"]');
+      if (btn) btn.click();
+    })();
+    """
+
+    static let resumeJS = """
+    (function(){
+      if (window.__pomoSCWidget) { window.__pomoSCWidget.play(); return; }
+      var media = document.querySelector('video,audio');
+      if (media) { media.play(); return; }
+      var btn = document.querySelector('.playControl:not(.playing), button.playControls__control[aria-label*="Play"]');
+      if (btn) btn.click();
+    })();
+    """
+
+    static let pauseJS = """
+    (function(){
+      if (window.__pomoSCWidget) { window.__pomoSCWidget.pause(); return; }
+      var media = document.querySelector('video,audio');
+      try { if (media) media.pause(); } catch(e) {}
+      var btn = document.querySelector('.playControl.playing, button.playControls__control[aria-label*="Pause"]');
+      if (btn) btn.click();
+    })();
+    """
+
+    static func setVolumeJS(_ volume: Int) -> String {
+        """
+        (function(){
+          var vol = \(volume);
+          if (window.__pomoSCWidget) { window.__pomoSCWidget.setVolume(vol); return; }
+          var media = document.querySelector('video,audio');
+          if (media) media.volume = vol / 100.0;
+        })();
+        """
+    }
+}

--- a/apps/macos/Sources/PomoShared/Audio/WebAudioPlayer.swift
+++ b/apps/macos/Sources/PomoShared/Audio/WebAudioPlayer.swift
@@ -3,8 +3,9 @@ import AppKit
 import CryptoKit
 import SwiftUI
 
-/// Plays YouTube / YouTube Music audio by driving the **real watch page's
-/// `<video>` element** in a small on-screen "mini-player" window. The IFrame
+/// Plays YouTube / YouTube Music / SoundCloud audio by driving the **real watch
+/// page's `<video>` element** (or the SoundCloud widget) in a small on-screen
+/// "mini-player" window. The IFrame
 /// embed is refused for embedding-restricted videos (error 150/152) and raw
 /// streams are PoToken-gated (403), so the live page is the reliable path — and
 /// once you sign in (Premium) it plays ad-free.
@@ -39,6 +40,7 @@ final class WebAudioPlayer: NSObject {
     private(set) var isPlaying = false
     private(set) var currentURL: String = ""
     private(set) var currentTitle: String = ""
+    private(set) var currentArtworkURL: String = ""
     private var volume: Int = 60
     private(set) var mediaTime: Double = 0
     private(set) var mediaDuration: Double = 0
@@ -111,6 +113,8 @@ final class WebAudioPlayer: NSObject {
 
     /// Signed-in YouTube identity, surfaced in Settings + the drawer avatar.
     let account = AccountStatus()
+    /// Signed-in SoundCloud identity, surfaced in Settings.
+    let soundCloudAccount = AccountStatus()
 
     /// Favorites, for the video menu's "Change Track" submenu. Weak — owned by
     /// AppDelegate; wired via `AudioController.bindFavorites`.
@@ -139,7 +143,9 @@ final class WebAudioPlayer: NSObject {
     private var cookieSaveWork: DispatchWorkItem?
     private var restoredSavedLogin = false
     private var restoreLoginTask: Task<Void, Never>?
-    private var persistedCookieSignature: String?
+    private var persistedCookieSignatures: [AuthService: String] = [:]
+    private var signInService: AuthService = .youTube
+    private var importLoginService: AuthService = .youTube
 
     override init() {
         super.init()
@@ -160,12 +166,13 @@ final class WebAudioPlayer: NSObject {
 
     func play(urlString raw: String, startAt: Double? = nil, knownTitle: String? = nil) {
         let urlString = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !urlString.isEmpty, let base = Self.watchURL(from: urlString) else { return }
+        guard !urlString.isEmpty, let base = Self.watchURL(from: urlString, pageMode: drawerExpanded) else { return }
         cancelIdleMemoryPurge()
         cancelBoundaryMemoryPurge()
         cancelPreparedBrowserSwap()
         currentURL = urlString
         currentTitle = knownTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        currentArtworkURL = ""
         pendingSeekTime = (startAt ?? 0) > 1 ? startAt : nil
         mediaTime = 0
         mediaDuration = 0
@@ -181,7 +188,7 @@ final class WebAudioPlayer: NSObject {
         Task { @MainActor in
             await self.restoreSavedLoginIfNeeded()
             guard self.currentURL == urlString else { return }
-            let url = Self.withAuthUser(base, self.authUser)
+            let url = Self.playbackRequestURL(base, source: urlString, authUser: self.authUser)
             self.log("play \(url.absoluteString)")
             self.webView?.load(URLRequest(url: url))
         }
@@ -206,13 +213,22 @@ final class WebAudioPlayer: NSObject {
             play(urlString: url)
             return
         }
-        eval("document.querySelector('video,audio')&&document.querySelector('video,audio').play();")
+        if PlaybackSource.detect(from: currentURL) == .soundCloud {
+            eval(PlaybackSource.resumeJS)
+        } else {
+            eval("document.querySelector('video,audio')&&document.querySelector('video,audio').play();")
+        }
         isPlaying = true
         persistPlaybackSnapshot(force: true, wasPlaying: true)
     }
 
     func pause() {
-        eval(Self.pauseAndSuspendScopeJS)
+        if PlaybackSource.detect(from: currentURL) == .soundCloud {
+            eval(PlaybackSource.pauseJS)
+            eval(Self.suspendAudioScopeJS)
+        } else {
+            eval(Self.pauseAndSuspendScopeJS)
+        }
         mediaTime = estimatedMediaTime()
         isPlaying = false
         mediaPaused = true
@@ -228,6 +244,7 @@ final class WebAudioPlayer: NSObject {
         }
         currentURL = ""
         currentTitle = ""
+        currentArtworkURL = ""
         isPlaying = false
         mediaTime = 0
         mediaDuration = 0
@@ -244,7 +261,11 @@ final class WebAudioPlayer: NSObject {
 
     func setVolume(_ value: Double) {
         volume = max(0, min(100, Int((value * 100).rounded())))
-        eval("var v=document.querySelector('video,audio'); if(v){v.volume=\(volume)/100.0;}")
+        if PlaybackSource.detect(from: currentURL) == .soundCloud {
+            eval(PlaybackSource.setVolumeJS(volume))
+        } else {
+            eval("var v=document.querySelector('video,audio'); if(v){v.volume=\(volume)/100.0;}")
+        }
     }
 
     func requestAudioScopePermission() {
@@ -302,8 +323,12 @@ final class WebAudioPlayer: NSObject {
         return max(0, time)
     }
 
-    /// Skip to the next track — works on YouTube playlists/radio and YT Music.
+    /// Skip to the next track — works on YouTube playlists/radio, YT Music, and SoundCloud sets.
     func next() {
+        if PlaybackSource.detect(from: currentURL) == .soundCloud {
+            eval(PlaybackSource.nextJS)
+            return
+        }
         eval(Self.clickJS([
             ".ytp-next-button",
             "ytmusic-player-bar .next-button button",
@@ -313,6 +338,10 @@ final class WebAudioPlayer: NSObject {
     }
 
     func previous() {
+        if PlaybackSource.detect(from: currentURL) == .soundCloud {
+            eval(PlaybackSource.previousJS)
+            return
+        }
         eval(Self.clickJS([
             "ytmusic-player-bar .previous-button button",
             "tp-yt-paper-icon-button.previous-button",
@@ -400,10 +429,16 @@ final class WebAudioPlayer: NSObject {
     /// and the chrome-stripped player view that matches the HUD.
     func setExpanded(_ on: Bool) {
         guard drawerOpen, let host = hostWindow, let anchor = anchorWindow else { return }
+        let wasExpanded = drawerExpanded
         drawerExpanded = on
         let a = anchor.frame
         let shade = isShadeAnchor(a)
-        applyBare(shade || !on)             // shade mode always uses the compact player sheet
+        if PlaybackSource.detect(from: currentURL) == .soundCloud, wasExpanded != on, !currentURL.isEmpty,
+           let url = Self.watchURL(from: currentURL, pageMode: on) {
+            let request = Self.playbackRequestURL(url, source: currentURL, authUser: authUser)
+            webView?.load(URLRequest(url: request))
+        }
+        applyBare(shouldApplyBare(shade: shade))
         applyDrawerCorners()
         updateExpandButton()
         onStateChange?()
@@ -567,7 +602,7 @@ final class WebAudioPlayer: NSObject {
         let shade = isShadeAnchor(a)
         drawerEdge = chooseEdge(a, screen)
         applyDrawerCorners()
-        applyBare(shade || !drawerExpanded)
+        applyBare(shouldApplyBare(shade: shade))
 
         let open = openFrame(size: size(for: drawerEdge, in: a), edge: drawerEdge, anchor: a, screen: screen)
         if host.parent === anchor { anchor.removeChildWindow(host) }
@@ -919,25 +954,29 @@ final class WebAudioPlayer: NSObject {
 
     // MARK: - Sign in (persistent profile)
 
-    func signIn() {
-        // A login needs keyboard focus, which an accessory app can't grab without
-        // becoming a regular app; revert when the window closes.
+    func signIn() { openSignInWindow(service: .youTube) }
+
+    func signInSoundCloud() { openSignInWindow(service: .soundCloud) }
+
+    private func openSignInWindow(service: AuthService) {
         NSApp.setActivationPolicy(.regular)
+        signInService = service
 
         if let signInWindow {
+            signInWindow.title = Self.signInWindowTitle(for: service)
             NSApp.activate(ignoringOtherApps: true)
             signInWindow.makeKeyAndOrderFront(nil)
             return
         }
 
         let config = WKWebViewConfiguration()
-        config.websiteDataStore = .default()     // shared with the player → login persists
+        config.websiteDataStore = .default()
         let frame = NSRect(x: 0, y: 0, width: 920, height: 720)
         let wv = WKWebView(frame: frame, configuration: config)
         wv.customUserAgent = Self.desktopUA
 
         let window = NSWindow(contentRect: frame, styleMask: [.titled, .closable, .resizable], backing: .buffered, defer: false)
-        window.title = "Sign in to YouTube / YouTube Music"
+        window.title = Self.signInWindowTitle(for: service)
         window.isReleasedWhenClosed = false
         window.contentView = wv
         window.center()
@@ -946,67 +985,86 @@ final class WebAudioPlayer: NSObject {
 
         Task { @MainActor in
             await self.restoreSavedLoginIfNeeded()
-            let continueURL = URL(string: "https://www.youtube.com/")!
-            wv.load(URLRequest(url: Self.serviceLoginURL(continueURL: continueURL, accountIndex: self.authUser)))
+            let request: URLRequest
+            switch service {
+            case .youTube:
+                let continueURL = AuthService.youTube.defaultContinueURL
+                request = URLRequest(url: Self.serviceLoginURL(continueURL: continueURL, accountIndex: self.authUser))
+            case .soundCloud:
+                request = URLRequest(url: AuthService.soundCloud.defaultContinueURL)
+            }
+            wv.load(request)
         }
         NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
     }
 
-    /// Borrow the YouTube login from a browser/profile (via the rookie helper)
-    /// and reload signed-in. Clears any prior Google/YouTube cookies first so
-    /// accounts/profiles don't mix. `browser` nil = all; `profile` e.g. "Profile 1".
+    /// Borrow a signed-in session from a browser/profile (via the rookie helper).
     func importCookies(fromBrowser browser: String?, profile: String?, accountIndex: Int = 0) {
         Task { @MainActor in
-            _ = await importLogin(fromBrowser: browser, profile: profile, accountIndex: accountIndex)
+            _ = await importLogin(fromBrowser: browser, profile: profile, service: .youTube, accountIndex: accountIndex)
         }
     }
 
-    /// Awaitable import that returns how many auth cookies were found, so callers
-    /// (e.g. the import panel) can report success vs "nothing found". Clears any
-    /// prior Google/YouTube cookies first so accounts/profiles don't mix.
+    func importSoundCloudCookies(fromBrowser browser: String?, profile: String?) {
+        Task { @MainActor in
+            _ = await importLogin(fromBrowser: browser, profile: profile, service: .soundCloud)
+        }
+    }
+
     @discardableResult
-    func importLogin(fromBrowser browser: String?, profile: String?, accountIndex: Int = 0) async -> Int {
+    func importLogin(
+        fromBrowser browser: String?,
+        profile: String?,
+        service: AuthService,
+        accountIndex: Int = 0
+    ) async -> Int {
         ensureWebView()
         guard let webView else { return 0 }
         let accountIndex = max(0, accountIndex)
         let label = [browser, profile].compactMap { $0 }.joined(separator: " / ")
-        log("importing cookies from \(label.isEmpty ? "all browsers" : label)…")
+        log("importing \(service.displayName) cookies from \(label.isEmpty ? "all browsers" : label)…")
         let store = webView.configuration.websiteDataStore.httpCookieStore
-        let cookies = await CookieImporter.cookies(fromBrowser: browser, profile: profile)
+        let cookies = await CookieImporter.cookies(fromBrowser: browser, profile: profile, service: service)
         guard !cookies.isEmpty else {
-            log("import found no cookies; keeping existing login")
+            log("import found no \(service.displayName) cookies; keeping existing login")
+            if service == .soundCloud {
+                log("hint: rebuild the app so pomo-cookies supports --soundcloud (scripts/run-app.sh)")
+            }
             return 0
         }
+        let domains = Set(cookies.map(\.domain)).sorted().joined(separator: ", ")
+        log("imported \(service.displayName) cookie domains: \(domains)")
 
         if let restoreLoginTask {
             await restoreLoginTask.value
             self.restoreLoginTask = nil
         }
-        let cleared = await Self.clearAuthCookies(store)
+        let cleared = await Self.clearAuthCookies(store, service: service)
         for cookie in cookies { await store.setCookie(cookie) }
-        let acceptedCookies = (await store.allCookies()).filter(Self.isPersistableAuthCookie)
-        let persistedCookies = acceptedCookies.isEmpty ? cookies.filter(Self.isPersistableAuthCookie) : acceptedCookies
-        CookieJar.save(persistedCookies)
+        let acceptedCookies = (await store.allCookies()).filter { Self.isPersistableAuthCookie($0, service: service) }
+        let persistedCookies = acceptedCookies.isEmpty
+            ? cookies.filter { Self.isPersistableAuthCookie($0, service: service) }
+            : acceptedCookies
+        CookieJar.save(persistedCookies, for: service)
         restoredSavedLogin = true
-        persistedCookieSignature = Self.cookieSignature(persistedCookies)
+        persistedCookieSignatures[service] = Self.cookieSignature(persistedCookies)
         cookieSaveWork?.cancel()
-        authUser = accountIndex
-        log("cleared \(cleared), imported \(cookies.count) cookies for account \(accountIndex)")
-        let targetURL: URL
-        if !currentURL.isEmpty, let base = Self.watchURL(from: currentURL) {
-            targetURL = Self.withAuthUser(base, accountIndex)
-        } else if let url = URL(string: "https://www.youtube.com/") {
-            targetURL = Self.withAuthUser(url, accountIndex)
-        } else {
-            return cookies.count
+        if service == .youTube { authUser = accountIndex }
+        if service == .soundCloud {
+            soundCloudAccount.signedIn = true
+            soundCloudAccount.name = "SoundCloud"
         }
-        webView.load(URLRequest(url: Self.serviceLoginURL(continueURL: targetURL, accountIndex: accountIndex)))
+        log("cleared \(cleared), imported \(cookies.count) \(service.displayName) cookies")
+        reloadAfterAuthChange(service: service, accountIndex: accountIndex, webView: webView)
         return cookies.count
     }
 
-    /// Sign out: drop all Google/YouTube cookies and reload.
-    func clearLogin() {
+    func clearLogin() { clearLogin(for: .youTube) }
+
+    func clearSoundCloudLogin() { clearLogin(for: .soundCloud) }
+
+    func clearLogin(for service: AuthService) {
         ensureWebView()
         guard let webView else { return }
         Task { @MainActor in
@@ -1014,15 +1072,53 @@ final class WebAudioPlayer: NSObject {
                 await restoreLoginTask.value
                 self.restoreLoginTask = nil
             }
-            let cleared = await Self.clearAuthCookies(webView.configuration.websiteDataStore.httpCookieStore)
-            self.authUser = 0
+            let cleared = await Self.clearAuthCookies(
+                webView.configuration.websiteDataStore.httpCookieStore,
+                service: service
+            )
+            if service == .youTube { self.authUser = 0 }
             self.restoredSavedLogin = true
-            self.persistedCookieSignature = nil
-            CookieJar.save([])   // write-through so logout survives an immediate quit
-            self.log("logout — cleared \(cleared) cookies")
-            if !self.currentURL.isEmpty, let url = Self.watchURL(from: self.currentURL) {
-                webView.load(URLRequest(url: url))
+            self.persistedCookieSignatures[service] = nil
+            CookieJar.save([], for: service)
+            if service == .youTube {
+                self.account.signedIn = false
+                self.account.name = nil
+                self.account.avatar = nil
+            } else {
+                self.soundCloudAccount.signedIn = false
+                self.soundCloudAccount.name = nil
+                self.soundCloudAccount.avatar = nil
             }
+            self.log("\(service.displayName) logout — cleared \(cleared) cookies")
+            self.reloadAfterAuthChange(service: service, accountIndex: 0, webView: webView)
+        }
+    }
+
+    private func reloadAfterAuthChange(service: AuthService, accountIndex: Int, webView: WKWebView) {
+        switch service {
+        case .youTube:
+            let targetURL: URL
+            if !currentURL.isEmpty, PlaybackSource.detect(from: currentURL) == .youTube,
+               let base = Self.watchURL(from: currentURL) {
+                targetURL = Self.withAuthUser(base, accountIndex)
+            } else {
+                targetURL = Self.withAuthUser(AuthService.youTube.defaultContinueURL, accountIndex)
+            }
+            webView.load(URLRequest(url: Self.serviceLoginURL(continueURL: targetURL, accountIndex: accountIndex)))
+        case .soundCloud:
+            if !currentURL.isEmpty, PlaybackSource.detect(from: currentURL) == .soundCloud,
+               let url = Self.watchURL(from: currentURL, pageMode: drawerExpanded) {
+                webView.load(URLRequest(url: url))
+            } else {
+                webView.load(URLRequest(url: AuthService.soundCloud.defaultContinueURL))
+            }
+        }
+    }
+
+    private static func signInWindowTitle(for service: AuthService) -> String {
+        switch service {
+        case .youTube: return "Sign in to YouTube / YouTube Music"
+        case .soundCloud: return "Sign in to SoundCloud"
         }
     }
 
@@ -1037,19 +1133,11 @@ final class WebAudioPlayer: NSObject {
     }
 
     @discardableResult
-    private static func clearAuthCookies(_ store: WKHTTPCookieStore) async -> Int {
+    private static func clearAuthCookies(_ store: WKHTTPCookieStore, service: AuthService) async -> Int {
         let existing = await store.allCookies()
-        let auth = existing.filter { isAuthDomain($0.domain) }
+        let auth = existing.filter { service.matches(domain: $0.domain) }
         for cookie in auth { await store.deleteCookie(cookie) }
         return auth.count
-    }
-
-    private static func isAuthDomain(_ domain: String) -> Bool {
-        let d = domain
-            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
-            .lowercased()
-        return d == "youtube.com" || d.hasSuffix(".youtube.com")
-            || d == "google.com" || d.hasSuffix(".google.com")
     }
 
     // MARK: - Login persistence (cookies on disk)
@@ -1066,12 +1154,20 @@ final class WebAudioPlayer: NSObject {
 
         let task = Task { @MainActor in
             defer { self.restoredSavedLogin = true }
-            let saved = CookieJar.load()
+            let saved = CookieJar.loadAll()
             guard !saved.isEmpty else { return }
             let store = self.webView?.configuration.websiteDataStore.httpCookieStore
                 ?? WKWebsiteDataStore.default().httpCookieStore
             for cookie in saved { await store.setCookie(cookie) }
-            self.persistedCookieSignature = Self.cookieSignature(saved)
+            for service in AuthService.allCases {
+                let serviceCookies = saved.filter { service.matches(domain: $0.domain) }
+                guard !serviceCookies.isEmpty else { continue }
+                self.persistedCookieSignatures[service] = Self.cookieSignature(serviceCookies)
+                if service == .soundCloud {
+                    self.soundCloudAccount.signedIn = true
+                    self.soundCloudAccount.name = "SoundCloud"
+                }
+            }
             self.log("restored \(saved.count) login cookies from disk")
         }
 
@@ -1105,18 +1201,24 @@ final class WebAudioPlayer: NSObject {
         let store = WKWebsiteDataStore.default().httpCookieStore
         Task { @MainActor in
             let all = await store.allCookies()
-            let cookies = all.filter(Self.isPersistableAuthCookie)
-            guard !cookies.isEmpty else { return }
-            let signature = Self.cookieSignature(cookies)
-            guard signature != self.persistedCookieSignature else { return }
-            CookieJar.save(cookies)
-            self.persistedCookieSignature = signature
-            self.log("persisted \(cookies.count) login cookies")
+            for service in AuthService.allCases {
+                let cookies = all.filter { Self.isPersistableAuthCookie($0, service: service) }
+                guard !cookies.isEmpty else { continue }
+                let signature = Self.cookieSignature(cookies)
+                guard signature != self.persistedCookieSignatures[service] else { continue }
+                CookieJar.save(cookies, for: service)
+                self.persistedCookieSignatures[service] = signature
+                if service == .soundCloud {
+                    self.soundCloudAccount.signedIn = true
+                    if self.soundCloudAccount.name == nil { self.soundCloudAccount.name = "SoundCloud" }
+                }
+                self.log("persisted \(cookies.count) \(service.displayName) login cookies")
+            }
         }
     }
 
-    private static func isPersistableAuthCookie(_ cookie: HTTPCookie) -> Bool {
-        guard isAuthDomain(cookie.domain), !cookie.value.isEmpty else { return false }
+    private static func isPersistableAuthCookie(_ cookie: HTTPCookie, service: AuthService) -> Bool {
+        guard service.matches(domain: cookie.domain), !cookie.value.isEmpty else { return false }
         if let expires = cookie.expiresDate, expires <= Date() { return false }
         return true
     }
@@ -1227,26 +1329,43 @@ final class WebAudioPlayer: NSObject {
     }
     @objc private func ctxSignIn() { signIn() }
     @objc private func ctxSignOut() { clearLogin() }
-    @objc private func ctxImportLogin() { showImportLogin() }
+    @objc private func ctxImportLogin() { showImportLogin(for: .youTube) }
+
+    func showImportLogin() { showImportLogin(for: .youTube) }
+
+    func showSoundCloudImportLogin() { showImportLogin(for: .soundCloud) }
 
     /// A tiny, guided window for importing a browser login (see `CookieImportPanel`).
-    func showImportLogin() {
+    func showImportLogin(for service: AuthService) {
         NSApp.setActivationPolicy(.regular)
+        if importLoginService != service, let staleImportWindow = importLoginWindow {
+            staleImportWindow.close()
+            self.importLoginWindow = nil
+        }
+        importLoginService = service
         if let importLoginWindow {
+            importLoginWindow.title = "Import \(service.displayName) Login"
             NSApp.activate(ignoringOtherApps: true)
             importLoginWindow.makeKeyAndOrderFront(nil)
             return
         }
+        let accountStatus = service == .youTube ? account : soundCloudAccount
         let view = CookieImportPanel(
-            account: account,
+            service: service,
+            account: accountStatus,
             profiles: CookieImporter.detectedProfiles(),
             onImport: { [weak self] browser, profile, accountIndex in
-                await self?.importLogin(fromBrowser: browser, profile: profile, accountIndex: accountIndex) ?? 0
+                await self?.importLogin(
+                    fromBrowser: browser,
+                    profile: profile,
+                    service: service,
+                    accountIndex: accountIndex
+                ) ?? 0
             },
             onClose: { [weak self] in self?.importLoginWindow?.close() }
         )
         let window = NSWindow(contentViewController: NSHostingController(rootView: view))
-        window.title = "Import YouTube Login"
+        window.title = "Import \(service.displayName) Login"
         window.styleMask = [.titled, .closable]
         // The panel draws its own titled header, so hide the window title (and
         // blend the titlebar into the content) to avoid showing it twice.
@@ -1942,10 +2061,20 @@ final class WebAudioPlayer: NSObject {
         })();
         """
         eval(js)
-        applyBare(!drawerExpanded)        // a fresh navigation re-asserts the bare default
-        eval(Self.accountJS)              // read the signed-in identity off the masthead
-        eval(Self.timestampKeyJS)
-        eval(Self.adSkipMonitorJS)
+        let source = PlaybackSource.detect(from: currentURL)
+        applyBare(shouldApplyBare())      // a fresh navigation re-asserts the bare default
+        if source == .soundCloud {
+            eval(PlaybackSource.playerAttachmentJS(
+                volume: volume,
+                restoreSeek: restoreSeekTime,
+                visualizerActive: visualizerActive,
+                scopeIntervalMs: audioScopeFrameIntervalMilliseconds
+            ))
+        } else {
+            eval(Self.accountJS)              // read the signed-in identity off the masthead
+            eval(Self.timestampKeyJS)
+            eval(Self.adSkipMonitorJS)
+        }
     }
 
     /// Reads the signed-in avatar (and best-effort name) from the YouTube /
@@ -2117,6 +2246,10 @@ final class WebAudioPlayer: NSObject {
             handleMediaTitle(String(message.dropFirst("title:".count)))
             return
         }
+        if message.hasPrefix("artwork:") {
+            handleMediaArtwork(String(message.dropFirst("artwork:".count)))
+            return
+        }
         if message == "scope:started" {
             log("scope started")
             return
@@ -2172,6 +2305,13 @@ final class WebAudioPlayer: NSObject {
         onStateChange?()
     }
 
+    private func handleMediaArtwork(_ encodedArtwork: String) {
+        let decoded = encodedArtwork.removingPercentEncoding ?? encodedArtwork
+        guard !decoded.isEmpty, decoded != currentArtworkURL else { return }
+        currentArtworkURL = decoded
+        onStateChange?()
+    }
+
     private static func cleanMediaTitle(_ raw: String) -> String {
         var title = raw
             .replacingOccurrences(of: "\n", with: " ")
@@ -2180,7 +2320,10 @@ final class WebAudioPlayer: NSObject {
         while title.contains("  ") {
             title = title.replacingOccurrences(of: "  ", with: " ")
         }
-        for suffix in [" - YouTube Music", " - YouTube", " | YouTube Music", " | YouTube"] {
+        for suffix in [
+            " - YouTube Music", " - YouTube", " | YouTube Music", " | YouTube",
+            " on SoundCloud", " | SoundCloud", " - SoundCloud",
+        ] {
             if title.lowercased().hasSuffix(suffix.lowercased()) {
                 title = String(title.dropLast(suffix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
             }
@@ -2657,31 +2800,24 @@ final class WebAudioPlayer: NSObject {
     // MARK: - URL helpers
 
     /// Normalise to a playable URL. YouTube Music links load as-is (the YT Music
-    /// app, which has radio/next); plain YouTube/youtu.be/bare-id → watch URL.
+    /// app, which has radio/next); plain YouTube/youtu.be/bare-id → watch URL;
+    /// SoundCloud links load through the embed widget (or the full page in page mode).
     static func isPlayableSource(_ raw: String) -> Bool {
         watchURL(from: raw) != nil
     }
 
-    private static func watchURL(from raw: String) -> URL? {
-        let normalized = normalizedSource(raw)
-        let host = URLComponents(string: normalized)?.host ?? ""
-        if host.contains("music.youtube.com") { return URL(string: normalized) }
-        if let id = youTubeID(from: normalized) { return URL(string: "https://www.youtube.com/watch?v=\(id)") }
-        guard let url = URL(string: normalized), url.scheme != nil else { return nil }
-        return url
+    private static func watchURL(from raw: String, pageMode: Bool = false) -> URL? {
+        PlaybackSource.playbackURL(from: raw, pageMode: pageMode)
     }
 
-    private static func normalizedSource(_ raw: String) -> String {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        let lower = trimmed.lowercased()
-        if lower.hasPrefix("youtube.com/")
-            || lower.hasPrefix("www.youtube.com/")
-            || lower.hasPrefix("m.youtube.com/")
-            || lower.hasPrefix("music.youtube.com/")
-            || lower.hasPrefix("youtu.be/") {
-            return "https://\(trimmed)"
-        }
-        return trimmed
+    private static func playbackRequestURL(_ base: URL, source raw: String, authUser: Int) -> URL {
+        PlaybackSource.detect(from: raw) == .youTube ? withAuthUser(base, authUser) : base
+    }
+
+    private func shouldApplyBare(shade: Bool = false) -> Bool {
+        if shade { return true }
+        guard PlaybackSource.detect(from: currentURL) == .youTube else { return false }
+        return !drawerExpanded
     }
 
     /// Append Google's `authuser=N` so multi-login picks the right account.
@@ -2695,25 +2831,7 @@ final class WebAudioPlayer: NSObject {
     }
 
     static func youTubeID(from string: String) -> String? {
-        let normalized = normalizedSource(string)
-        if let comps = URLComponents(string: normalized) {
-            let host = comps.host ?? ""
-            if host.contains("youtu.be") {
-                let id = comps.path.split(separator: "/").first.map(String.init)
-                if let id, isID(id) { return id }
-            }
-            if host.contains("youtube.com") {
-                if let v = comps.queryItems?.first(where: { $0.name == "v" })?.value, isID(v) { return v }
-                let parts = comps.path.split(separator: "/").map(String.init)
-                if let idx = parts.firstIndex(where: { ["embed", "live", "shorts", "v"].contains($0) }),
-                   idx + 1 < parts.count, isID(parts[idx + 1]) { return parts[idx + 1] }
-            }
-        }
-        return isID(normalized) ? normalized : nil
-    }
-
-    private static func isID(_ s: String) -> Bool {
-        s.range(of: "^[A-Za-z0-9_-]{11}$", options: .regularExpression) != nil
+        PlaybackSource.youTubeID(from: string)
     }
 
     /// JS that clicks the first matching selector (for next/prev across surfaces).
@@ -2727,12 +2845,20 @@ extension WebAudioPlayer: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
         let window = notification.object as? NSWindow
         if window === signInWindow {
+            let service = signInService
             signInWindow = nil
             NSApp.setActivationPolicy(.accessory)
-            // The account is read off the *player's* page, not the sign-in
-            // window, so reload the player to pick up the freshly-signed-in
-            // session (otherwise a web sign-in never registers in the app).
-            reloadForLogin()
+            switch service {
+            case .youTube:
+                reloadForLogin()
+            case .soundCloud:
+                soundCloudAccount.signedIn = true
+                if soundCloudAccount.name == nil { soundCloudAccount.name = "SoundCloud" }
+                if let webView, !currentURL.isEmpty, PlaybackSource.detect(from: currentURL) == .soundCloud,
+                   let url = Self.watchURL(from: currentURL, pageMode: drawerExpanded) {
+                    webView.load(URLRequest(url: url))
+                }
+            }
         } else if window === importLoginWindow {
             importLoginWindow = nil
             NSApp.setActivationPolicy(.accessory)

--- a/apps/macos/Sources/PomoShared/Control/FavoritesStore.swift
+++ b/apps/macos/Sources/PomoShared/Control/FavoritesStore.swift
@@ -148,10 +148,8 @@ final class FavoritesStore {
         onChange?()
     }
 
-    /// A readable fallback title from the URL (YouTube id, or host).
+    /// A readable fallback title from the URL (source label, or host).
     private static func defaultTitle(for url: String) -> String {
-        if let id = WebAudioPlayer.youTubeID(from: url) { return "YouTube · \(id)" }
-        if let host = URLComponents(string: url)?.host { return host }
-        return url
+        PlaybackSource.shortLabel(for: url)
     }
 }

--- a/apps/macos/Sources/PomoShared/HUD/HUDRootView.swift
+++ b/apps/macos/Sources/PomoShared/HUD/HUDRootView.swift
@@ -964,14 +964,14 @@ private struct QuickEntryOverlay: View {
 
     private var title: String {
         switch field {
-        case .video:           return "PASTE A YOUTUBE OR AUDIO LINK"
+        case .video:           return "PASTE A YOUTUBE, SOUNDCLOUD, OR AUDIO LINK"
         case .intent, .none:   return "WHAT ARE YOU WORKING ON?"
         }
     }
 
     private var placeholder: String {
         switch field {
-        case .video:           return "https://youtube.com/watch?v=…"
+        case .video:           return "https://youtube.com/… or soundcloud.com/…"
         case .intent, .none:   return "e.g. Writing the launch post"
         }
     }

--- a/apps/macos/Sources/PomoShared/MenuBar/MenuPopoverView.swift
+++ b/apps/macos/Sources/PomoShared/MenuBar/MenuPopoverView.swift
@@ -726,12 +726,15 @@ struct MenuPopoverView: View {
         height: CGFloat,
         iconSize: CGFloat = 15
     ) -> some View {
-        let id = WebAudioPlayer.youTubeID(from: urlString)
+        let artwork = PlaybackSource.artworkURL(
+            for: urlString,
+            liveArtwork: urlString == displayedAudioURL ? audio.currentArtworkURL : ""
+        )
         RoundedRectangle(cornerRadius: HudRadius.standard, style: .continuous)
             .fill(controlFill)
             .frame(width: width, height: height)
             .overlay {
-                if let id, let url = URL(string: "https://img.youtube.com/vi/\(id)/mqdefault.jpg") {
+                if let artwork, let url = URL(string: artwork) {
                     AsyncImage(url: url) { phase in
                         if let image = phase.image {
                             image.resizable().aspectRatio(contentMode: .fill)
@@ -763,8 +766,7 @@ struct MenuPopoverView: View {
     }
 
     private static func shortURL(_ string: String) -> String {
-        if let id = WebAudioPlayer.youTubeID(from: string) { return "youtube · \(id)" }
-        return URLComponents(string: string)?.host ?? string
+        PlaybackSource.shortLabel(for: string)
     }
 
     // MARK: - Footer

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpHUDRootView.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpHUDRootView.swift
@@ -169,7 +169,7 @@ struct PomoAmpHUDRootView: View {
                     onHide?()
                 }
                 Spacer(minLength: 0)
-                chromeButton("doc.on.clipboard", help: "Paste YouTube URL") {
+                chromeButton("doc.on.clipboard", help: "Paste YouTube or SoundCloud URL") {
                     onPasteURL()
                 }
                 openPomoButton()
@@ -439,7 +439,7 @@ struct PomoAmpHUDRootView: View {
                 .font(HudFont.mono(HudTextSize.xs, weight: .black))
                 .tracking(2)
                 .foregroundStyle(accent)
-            Text("YouTube deck")
+            Text("Music deck")
                 .font(HudFont.mono(HudTextSize.micro, weight: .semibold))
                 .foregroundStyle(Color.white.opacity(0.48))
             Spacer(minLength: 0)
@@ -535,7 +535,7 @@ struct PomoAmpHUDRootView: View {
             }
             deckButton("forward.end.fill", help: "Next track") { playAdjacentTrack(1) }
             divider
-            deckButton("doc.on.clipboard", help: "Paste YouTube URL") { onPasteURL() }
+            deckButton("doc.on.clipboard", help: "Paste YouTube or SoundCloud URL") { onPasteURL() }
             deckButton(audio.videoOpen ? "rectangle.fill" : "play.rectangle", help: audio.videoOpen ? "Hide video" : "Show video") {
                 onToggleDrawer()
             }
@@ -603,7 +603,7 @@ struct PomoAmpHUDRootView: View {
             Button(audio.isPlaying ? "Pause" : "Play") { onToggleAudio() }
             Button("Previous Timestamp Section") { onPreviousSection() }
             Button("Next Timestamp Section") { onNextSection() }
-            Button("Paste YouTube URL") { onPasteURL() }
+            Button("Paste URL") { onPasteURL() }
             Button(audio.videoOpen ? "Hide Video" : "Show Video") { onToggleDrawer() }
             Button(audio.videoExpanded ? "Show Player" : "Show Page") {
                 if audio.videoExpanded {
@@ -762,7 +762,7 @@ struct PomoAmpHUDRootView: View {
         if !title.isEmpty {
             return title
         }
-        guard !activeURL.isEmpty else { return "Paste a YouTube URL" }
+        guard !activeURL.isEmpty else { return "Paste a YouTube or SoundCloud URL" }
         return Self.shortURL(activeURL)
     }
 
@@ -772,8 +772,7 @@ struct PomoAmpHUDRootView: View {
     }
 
     private var thumbnailURL: String {
-        guard let id = WebAudioPlayer.youTubeID(from: activeURL) else { return "" }
-        return "https://img.youtube.com/vi/\(id)/hqdefault.jpg"
+        PlaybackSource.artworkURL(for: activeURL, liveArtwork: audio.currentArtworkURL) ?? ""
     }
 
     private static func shortURL(_ raw: String) -> String {

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpMenuBarController.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpMenuBarController.swift
@@ -143,7 +143,7 @@ final class PomoAmpMenuBarController: NSObject, NSPopoverDelegate {
         addItem(audio.isPlaying ? "Pause" : "Play", to: menu, action: #selector(toggleAudio))
         addItem("Previous Timestamp Section", to: menu, action: #selector(previousSection))
         addItem("Next Timestamp Section", to: menu, action: #selector(nextSection))
-        addItem("Paste YouTube URL", to: menu, action: #selector(pasteURL))
+        addItem("Paste URL", to: menu, action: #selector(pasteURL))
         addItem(audio.videoOpen ? "Hide Video" : "Show Video", to: menu, action: #selector(toggleDrawer))
         addItem(audio.videoExpanded ? "Show Player" : "Show Page", to: menu, action: #selector(togglePageMode))
         addItem((isCompactMode?() ?? false) ? "Expand" : "Compact Mode", to: menu, action: #selector(toggleCompactMode))

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpMenuPopoverView.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpMenuPopoverView.swift
@@ -37,7 +37,7 @@ struct PomoAmpMenuPopoverView: View {
             header
             nowPlaying
             transport
-            section("YOUTUBE") { youtubeControls }
+            section("LIBRARY") { youtubeControls }
             section("FAVORITES") { favoritesList }
             section("FACE") { faceStrip }
             footer
@@ -188,7 +188,7 @@ struct PomoAmpMenuPopoverView: View {
     private var favoritesList: some View {
         Group {
             if favorites.items.isEmpty {
-                Text("No saved YouTube links")
+                Text("No saved links")
                     .font(HudFont.ui(HudTextSize.xs, weight: .medium))
                     .foregroundStyle(Color.white.opacity(0.42))
                     .frame(maxWidth: .infinity, minHeight: 34, alignment: .leading)
@@ -379,12 +379,15 @@ struct PomoAmpMenuPopoverView: View {
 
     @ViewBuilder
     private func thumbnail(for urlString: String, width: CGFloat, height: CGFloat, iconSize: CGFloat) -> some View {
-        let id = WebAudioPlayer.youTubeID(from: urlString)
+        let artwork = PlaybackSource.artworkURL(
+            for: urlString,
+            liveArtwork: urlString == currentURL ? audio.currentArtworkURL : ""
+        )
         RoundedRectangle(cornerRadius: 8, style: .continuous)
             .fill(Color.white.opacity(0.07))
             .frame(width: width, height: height)
             .overlay {
-                if let id, let url = URL(string: "https://img.youtube.com/vi/\(id)/mqdefault.jpg") {
+                if let artwork, let url = URL(string: artwork) {
                     AsyncImage(url: url) { phase in
                         if let image = phase.image {
                             image
@@ -412,12 +415,12 @@ struct PomoAmpMenuPopoverView: View {
         }
         let title = audio.currentTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         if !title.isEmpty { return title }
-        guard !currentURL.isEmpty else { return "Paste a YouTube URL" }
+        guard !currentURL.isEmpty else { return "Paste a YouTube or SoundCloud URL" }
         return Self.shortURL(currentURL)
     }
 
     private var sourceLabel: String {
-        guard let host = URL(string: currentURL)?.host else { return "youtube deck" }
+        guard let host = URL(string: currentURL)?.host else { return "music deck" }
         return host.replacingOccurrences(of: "www.", with: "")
     }
 

--- a/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpSkinStore.swift
+++ b/apps/macos/Sources/PomoShared/PomoAmp/PomoAmpSkinStore.swift
@@ -63,10 +63,29 @@ public enum PomoAmpSkinStore {
         }
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try? exampleManifest.write(to: manifestURL, atomically: true, encoding: .utf8)
-        try? PomoAmpDefaultSkinHTML.html.write(to: directory.appendingPathComponent("index.html"), atomically: true, encoding: .utf8)
+        installBundledDefaultSkin(to: directory)
     }
 
-    private static let exampleVersion = "1.1.10"
+    private static func installBundledDefaultSkin(to directory: URL) {
+        guard let sourceURL = Bundle.module.url(
+            forResource: "index",
+            withExtension: "html",
+            subdirectory: "PomoAmpDefaultSkin"
+        ) else {
+            PomoAmpDebugLog.write("bundled default skin index.html missing")
+            return
+        }
+
+        let targetURL = directory.appendingPathComponent("index.html")
+        try? FileManager.default.removeItem(at: targetURL)
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: targetURL)
+        } catch {
+            PomoAmpDebugLog.write("failed to install bundled default skin: \(error)")
+        }
+    }
+
+    private static let exampleVersion = "1.2.1"
 
     private static let exampleManifest = """
     {

--- a/apps/macos/Sources/PomoShared/Resources/PomoAmpDefaultSkin/index.html
+++ b/apps/macos/Sources/PomoShared/Resources/PomoAmpDefaultSkin/index.html
@@ -1,7 +1,3 @@
-import Foundation
-
-enum PomoAmpDefaultSkinHTML {
-    static let html = #"""
 <!doctype html>
 <html>
 <head>
@@ -769,8 +765,13 @@ enum PomoAmpDefaultSkinHTML {
 
   <script>
     const presets = [
+      { name: "Focus Halo", short: "HALO", face: "nowplaying", treatment: "halo" },
+      { name: "Orbit Drift", short: "ORBIT", face: "ambient", treatment: "orbit" },
+      { name: "Signal Lattice", short: "LATTICE", face: "scope", treatment: "lattice" },
       { name: "Signal Card", short: "SIGNAL", face: "signal", treatment: "signal" },
       { name: "Studio Deck", short: "STUDIO", face: "deck", treatment: "deck" },
+      { name: "Console Spectro", short: "SPECTRO", face: "studio", treatment: "spectro" },
+      { name: "Module Bandprint", short: "BANDS", face: "modules", treatment: "bandprint" },
       { name: "MiniDisc Frost", short: "MINIDISC", face: "minidisc", treatment: "minidisc" }
     ];
 
@@ -779,7 +780,7 @@ enum PomoAmpDefaultSkinHTML {
       bands: [], waveform: [], rms: 0, peak: 0, bpmEstimate: 0, beatPhase: 0,
       centroidHz: 0, rolloff85Hz: 0, flux: 0, low: 0, mid: 0, high: 0,
       sub: 0, presence: 0, brilliance: 0, transient: 0, drop: 0,
-      crest: 0, peakDb: -90, rmsDb: -90
+      crest: 0, crestDb: 0, onsetPulse: 0, onsetScore: 0, peakDb: -90, rmsDb: -90
     };
 
     var state = { isPlaying: false, title: "Pomo Amp", source: "youtube.com", videoOpen: false, videoExpanded: false };
@@ -792,7 +793,7 @@ enum PomoAmpDefaultSkinHTML {
       canvasIdleDelayMilliseconds: 1200,
       canvasMaxDevicePixelRatio: 1.35
     };
-    const skinBuild = "1.1.10";
+    const skinBuild = "1.2.1";
     if (localStorage.getItem("pomoAmp.defaultSkin.build") !== skinBuild) {
       localStorage.setItem("pomoAmp.defaultSkin.build", skinBuild);
       localStorage.setItem("pomoAmp.defaultSkin.preset", "0");
@@ -805,6 +806,18 @@ enum PomoAmpDefaultSkinHTML {
     const spectroColumns = 90;
     const peakHistory = [];
     const gain = { bandPeaks: [], wavePeak: 0.08, rmsPeak: 0.05, energy: 0 };
+    const signal = {
+      serial: -1,
+      low: 0,
+      mid: 0,
+      high: 0,
+      energy: 0,
+      slowEnergy: 0,
+      beat: 0,
+      onset: 0,
+      bands: [],
+      wave: []
+    };
     var drawTimer = 0;
     var drawScheduled = false;
     var lastDrawTime = 0;
@@ -919,6 +932,49 @@ enum PomoAmpDefaultSkinHTML {
       const target = clamp(raw / gain.rmsPeak);
       gain.energy += (target - gain.energy) * 0.22;
       return clamp(gain.energy);
+    }
+
+    function averageSlice(values, start, end) {
+      const lower = Math.max(0, Math.min(values.length, start));
+      const upper = Math.max(lower + 1, Math.min(values.length, end));
+      let total = 0;
+      for (let i = lower; i < upper; i += 1) total += Number(values[i]) || 0;
+      return total / Math.max(1, upper - lower);
+    }
+
+    function smoothSignal(previous, next, attack = 0.30, decay = 0.12) {
+      const rate = next > previous ? attack : decay;
+      return previous + (next - previous) * rate;
+    }
+
+    function audioSignal() {
+      if (signal.serial === vizSerial) return signal;
+      const bs = normalizedBands();
+      const xs = normalizedWave();
+      const count = bs.length || 24;
+      const lowEnd = Math.max(2, Math.floor(count * 0.25));
+      const midEnd = Math.max(lowEnd + 1, Math.floor(count * 0.62));
+      const rawLow = clamp(Number(viz.low) || averageSlice(bs, 0, lowEnd));
+      const rawMid = clamp(Number(viz.mid) || averageSlice(bs, lowEnd, midEnd));
+      const rawHigh = clamp(Number(viz.high) || averageSlice(bs, midEnd, count));
+      const energy = liveEnergy();
+      signal.slowEnergy += (energy - signal.slowEnergy) * 0.04;
+      const energyOnset = clamp((energy - signal.slowEnergy) * 4.0);
+      const onset = Math.max(
+        clamp(Number(viz.onsetPulse) || 0),
+        energyOnset,
+        clamp((Number(viz.drop) || 0) * 0.74)
+      );
+      signal.low = smoothSignal(signal.low, rawLow);
+      signal.mid = smoothSignal(signal.mid, rawMid);
+      signal.high = smoothSignal(signal.high, rawHigh);
+      signal.energy = smoothSignal(signal.energy, energy);
+      signal.onset = onset;
+      signal.beat = Math.max(onset, signal.beat * 0.82);
+      signal.bands = bs;
+      signal.wave = xs;
+      signal.serial = vizSerial;
+      return signal;
     }
 
     function mediaProgress() {
@@ -1100,7 +1156,7 @@ enum PomoAmpDefaultSkinHTML {
       const energy = liveEnergy();
       const rms = energy;
       const peak = clamp((Number(viz.peak) || 0) / Math.max(0.04, gain.rmsPeak));
-      const crest = clamp((viz.crest || 0) / 16);
+      const crest = clamp((Number(viz.crestDb) || Number(viz.crest) || 0) / 16);
       const margin = 18;
       const meterH = Math.max(18, h * 0.16);
       [["RMS", rms, "#79f2ad"], ["PEAK", peak, "#ff9b52"], ["CREST", crest, "#86b8ff"]].forEach((row, i) => {
@@ -1351,7 +1407,196 @@ enum PomoAmpDefaultSkinHTML {
       ctx.stroke();
     }
 
+    function drawFocusHalo(canvas) {
+      const pack = resizeCanvas(canvas);
+      if (!pack) return;
+      const { ctx, w, h } = pack;
+      const s = audioSignal();
+      const t = Number(viz.hostTime) || performance.now() / 1000;
+      const progress = mediaProgress();
+      ctx.fillStyle = "rgba(3,5,6,0.96)";
+      ctx.fillRect(0, 0, w, h);
+
+      const wash = ctx.createLinearGradient(0, 0, w, h);
+      wash.addColorStop(0, `rgba(143,216,194,${0.055 + s.energy * 0.08})`);
+      wash.addColorStop(0.58, `rgba(198,164,106,${0.030 + s.mid * 0.08})`);
+      wash.addColorStop(1, "rgba(6,8,10,0.88)");
+      ctx.fillStyle = wash;
+      ctx.fillRect(0, 0, w, h);
+
+      const margin = 18 + s.beat * 5;
+      const rx = margin + s.low * 5;
+      const ry = margin + s.mid * 4;
+      const rw = Math.max(1, w - rx * 2);
+      const rh = Math.max(1, h - ry * 2);
+      for (let i = 0; i < 4; i += 1) {
+        const inset = i * (5 + s.energy * 2);
+        ctx.strokeStyle = i % 2
+          ? `rgba(198,164,106,${0.10 + s.high * 0.18})`
+          : `rgba(143,216,194,${0.16 + s.low * 0.22})`;
+        ctx.lineWidth = 1.1 + s.energy * 2.4 + i * 0.25;
+        ctx.strokeRect(rx + inset, ry + inset, Math.max(1, rw - inset * 2), Math.max(1, rh - inset * 2));
+      }
+
+      const meterY = ry + rh - 13;
+      ctx.fillStyle = "rgba(242,241,236,0.08)";
+      ctx.fillRect(rx + 8, meterY, Math.max(1, rw - 16), 3);
+      ctx.fillStyle = `rgba(143,216,194,${0.42 + s.energy * 0.30})`;
+      ctx.fillRect(rx + 8, meterY, Math.max(10, (rw - 16) * progress), 3 + s.beat * 3);
+
+      const wave = s.wave;
+      ctx.lineWidth = 1.2 + s.energy * 1.7;
+      ctx.strokeStyle = `rgba(242,241,236,${0.28 + s.energy * 0.25})`;
+      ctx.beginPath();
+      wave.forEach((sample, i) => {
+        const x = rx + 12 + i / Math.max(1, wave.length - 1) * Math.max(1, rw - 24);
+        const y = ry + rh * 0.50 - clamp(sample, -1, 1) * (rh * (0.10 + s.energy * 0.13));
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+
+      const bars = s.bands;
+      const barW = Math.max(1, (rw - 20) / Math.max(1, bars.length));
+      bars.forEach((value, i) => {
+        const v = clamp(value);
+        const x = rx + 10 + i * barW;
+        const bh = rh * (0.04 + v * (0.20 + s.beat * 0.06));
+        ctx.fillStyle = i > bars.length * 0.66 ? "rgba(198,164,106,0.44)" : "rgba(143,216,194,0.36)";
+        ctx.fillRect(x, ry + rh - 20 - bh, Math.max(1, barW - 1), bh);
+      });
+
+      ctx.fillStyle = `rgba(255,155,82,${0.24 + s.beat * 0.42})`;
+      const sparkCount = 4;
+      for (let i = 0; i < sparkCount; i += 1) {
+        const u = (progress + i / sparkCount + t * 0.025) % 1;
+        const side = Math.floor(u * 4);
+        const p = (u * 4) % 1;
+        const x = side === 0 ? rx + p * rw : side === 1 ? rx + rw : side === 2 ? rx + (1 - p) * rw : rx;
+        const y = side === 0 ? ry : side === 1 ? ry + p * rh : side === 2 ? ry + rh : ry + (1 - p) * rh;
+        ctx.beginPath();
+        ctx.arc(x, y, 2.0 + s.high * 3 + s.beat * 2, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    function drawOrbitDrift(canvas) {
+      const pack = resizeCanvas(canvas);
+      if (!pack) return;
+      const { ctx, w, h } = pack;
+      const s = audioSignal();
+      const t = Number(viz.hostTime) || performance.now() / 1000;
+      const cx = w * 0.5;
+      const cy = h * 0.48;
+      const span = Math.min(w, h);
+      ctx.fillStyle = "rgba(2,4,5,0.94)";
+      ctx.fillRect(0, 0, w, h);
+
+      const bg = ctx.createLinearGradient(0, 0, w, h);
+      bg.addColorStop(0, `rgba(143,216,194,${0.07 + s.energy * 0.08})`);
+      bg.addColorStop(0.64, `rgba(198,164,106,${0.04 + s.high * 0.08})`);
+      bg.addColorStop(1, "rgba(0,0,0,0.38)");
+      ctx.fillStyle = bg;
+      ctx.fillRect(0, 0, w, h);
+
+      const rings = [
+        [0.22, s.low, "rgba(143,216,194,"],
+        [0.34, s.mid, "rgba(213,233,141,"],
+        [0.47, s.high, "rgba(198,164,106,"]
+      ];
+      rings.forEach((ring, ringIndex) => {
+        const radius = span * (ring[0] + s.energy * 0.035 + s.beat * 0.018);
+        ctx.strokeStyle = `${ring[2]}${0.13 + ring[1] * 0.30})`;
+        ctx.lineWidth = 1 + ring[1] * 3;
+        ctx.beginPath();
+        ctx.ellipse(cx, cy, radius * 1.45, radius * 0.62, -0.18 + ringIndex * 0.17, 0, Math.PI * 2);
+        ctx.stroke();
+      });
+
+      const beads = Math.min(32, Math.max(12, s.bands.length));
+      for (let i = 0; i < beads; i += 1) {
+        const v = s.bands[Math.floor(i / beads * Math.max(1, s.bands.length))] || 0;
+        const orbit = i % 3;
+        const radius = span * ([0.22, 0.34, 0.47][orbit] + s.energy * 0.03);
+        const angle = i / beads * Math.PI * 2 + t * (0.13 + orbit * 0.045) + s.beat * 0.45;
+        const x = cx + Math.cos(angle) * radius * 1.45;
+        const y = cy + Math.sin(angle) * radius * 0.62;
+        ctx.fillStyle = orbit === 2
+          ? `rgba(198,164,106,${0.20 + v * 0.62})`
+          : `rgba(143,216,194,${0.18 + v * 0.58})`;
+        ctx.beginPath();
+        ctx.arc(x, y, 1.5 + v * 4.8 + s.beat * 1.4, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      ctx.fillStyle = `rgba(242,241,236,${0.10 + s.energy * 0.22})`;
+      ctx.beginPath();
+      ctx.arc(cx, cy, span * (0.035 + s.low * 0.045), 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    function drawSignalLattice(canvas) {
+      const pack = resizeCanvas(canvas);
+      if (!pack) return;
+      const { ctx, w, h } = pack;
+      const s = audioSignal();
+      const xs = s.wave;
+      ctx.fillStyle = "rgba(1,8,7,0.94)";
+      ctx.fillRect(0, 0, w, h);
+
+      const laneHeight = h / 3;
+      const lanes = [
+        ["LOW", s.low, "rgba(143,216,194,"],
+        ["MID", s.mid, "rgba(213,233,141,"],
+        ["AIR", s.high, "rgba(198,164,106,"]
+      ];
+      lanes.forEach((lane, laneIndex) => {
+        const y = laneIndex * laneHeight;
+        ctx.fillStyle = laneIndex % 2 ? "rgba(255,255,255,0.025)" : "rgba(255,255,255,0.040)";
+        ctx.fillRect(0, y, w, laneHeight);
+        ctx.strokeStyle = `${lane[2]}${0.14 + lane[1] * 0.18})`;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(0, y + laneHeight * 0.5);
+        ctx.lineTo(w, y + laneHeight * 0.5);
+        ctx.stroke();
+        ctx.fillStyle = "rgba(242,241,236,0.36)";
+        ctx.font = "900 8px ui-monospace";
+        ctx.fillText(lane[0], 8, y + 14);
+      });
+
+      const bars = s.bands;
+      const barW = Math.max(1, w / Math.max(1, bars.length));
+      bars.forEach((value, i) => {
+        const v = clamp(value);
+        const laneIndex = i < bars.length * 0.25 ? 0 : i < bars.length * 0.62 ? 1 : 2;
+        const laneTop = laneIndex * laneHeight;
+        const bh = Math.max(1, v * laneHeight * 0.72);
+        ctx.fillStyle = laneIndex === 2 ? "rgba(255,155,82,0.46)" : laneIndex === 1 ? "rgba(213,233,141,0.38)" : "rgba(143,216,194,0.42)";
+        ctx.fillRect(i * barW, laneTop + laneHeight - bh, Math.max(1, barW - 1), bh);
+      });
+
+      ctx.lineWidth = 1.5 + s.energy * 2.0 + s.beat;
+      ctx.strokeStyle = `rgba(143,216,194,${0.72 + s.energy * 0.24})`;
+      ctx.shadowColor = "rgba(143,216,194,0.42)";
+      ctx.shadowBlur = 6 + s.beat * 12;
+      ctx.beginPath();
+      xs.forEach((sample, i) => {
+        const x = i / Math.max(1, xs.length - 1) * w;
+        const y = h * 0.50 - clamp(sample, -1, 1) * (h * (0.10 + s.energy * 0.12));
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+      ctx.shadowBlur = 0;
+
+      const markerX = clamp(viz.progress || mediaProgress()) * w;
+      ctx.fillStyle = `rgba(255,155,82,${0.36 + s.beat * 0.36})`;
+      ctx.fillRect(markerX - 1, 0, 2 + s.beat * 4, h);
+    }
+
     const treatmentDraw = {
+      halo: drawFocusHalo,
+      orbit: drawOrbitDrift,
+      lattice: drawSignalLattice,
       wave: drawWaveTrace,
       spectro: drawSpectro,
       headroom: drawHeadroom,
@@ -1726,8 +1971,6 @@ enum PomoAmpDefaultSkinHTML {
     mountFace();
     scheduleDraw(0);
     window.yamp?.ready?.();
-  </script>
+</script>
 </body>
 </html>
-"""#
-}

--- a/apps/macos/Sources/PomoShared/Settings/CookieImportPanel.swift
+++ b/apps/macos/Sources/PomoShared/Settings/CookieImportPanel.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 import HudsonUI
 
-/// A tiny, guided panel for borrowing a YouTube login from a browser the user is
-/// already signed into — so the web player goes ad-free without a fresh sign-in.
-/// Chromium-family browsers expose multiple profiles, so we make those choices
-/// explicit instead of importing from an ambiguous browser-level default.
+/// A tiny, guided panel for borrowing a web-player login from a browser the user
+/// is already signed into. Chromium-family browsers expose multiple profiles, so
+/// we make those choices explicit instead of importing from an ambiguous default.
 struct CookieImportPanel: View {
+    var service: AuthService = .youTube
     var account: AccountStatus
     var profiles: [CookieImporter.BrowserProfile]
     /// Imports auth cookies from the given browser/profile; returns how many it found.
@@ -98,10 +98,10 @@ struct CookieImportPanel: View {
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(pal.accent)
             VStack(alignment: .leading, spacing: 1) {
-                Text("Import YouTube Login")
+                Text("Import \(service.displayName) Login")
                     .font(HudFont.mono(HudTextSize.md, weight: .semibold))
                     .foregroundStyle(pal.ink)
-                Text("Choose the browser profile signed into YouTube")
+                Text("Choose the browser profile signed into \(service.displayName)")
                     .font(HudFont.ui(HudTextSize.xs))
                     .foregroundStyle(pal.dim)
             }
@@ -112,12 +112,14 @@ struct CookieImportPanel: View {
 
     private var chooseStep: some View {
         VStack(alignment: .leading, spacing: HudSpacing.lg) {
-            Text("Pick the same profile you use for YouTube. Chrome-based browsers may ask for Keychain access.")
+            Text("Pick the same profile you use for \(service.displayName). Chrome-based browsers may ask for Keychain access.")
                 .font(HudFont.ui(HudTextSize.xs))
                 .foregroundStyle(pal.muted)
                 .fixedSize(horizontal: false, vertical: true)
 
-            accountPicker
+            if service == .youTube {
+                accountPicker
+            }
 
             ScrollView {
                 VStack(alignment: .leading, spacing: HudSpacing.md) {
@@ -252,9 +254,15 @@ struct CookieImportPanel: View {
                 Text("Signed in as \(account.name ?? "your account")")
                     .font(HudFont.ui(HudTextSize.sm, weight: .semibold))
                     .foregroundStyle(pal.ink)
-                Label("Ad-free with Premium", systemImage: "checkmark.seal.fill")
-                    .font(HudFont.ui(HudTextSize.xs, weight: .medium))
-                    .foregroundStyle(pal.action)
+                if service == .youTube {
+                    Label("Ad-free with Premium", systemImage: "checkmark.seal.fill")
+                        .font(HudFont.ui(HudTextSize.xs, weight: .medium))
+                        .foregroundStyle(pal.action)
+                } else {
+                    Label("Signed in for playlists and library", systemImage: "checkmark.seal.fill")
+                        .font(HudFont.ui(HudTextSize.xs, weight: .medium))
+                        .foregroundStyle(pal.action)
+                }
                 button("Done", kind: .primary, action: onClose)
             }
             .frame(maxWidth: .infinity)
@@ -264,7 +272,7 @@ struct CookieImportPanel: View {
                 Label(
                     importedCount > 0
                         ? "Imported \(importedCount) cookies from \(pickedName)."
-                        : "No YouTube login found in \(pickedName).",
+                        : "No \(service.displayName) login found in \(pickedName).",
                     systemImage: importedCount > 0 ? "checkmark.circle.fill" : "xmark.circle.fill"
                 )
                 .font(HudFont.ui(HudTextSize.sm))
@@ -272,7 +280,7 @@ struct CookieImportPanel: View {
                 .fixedSize(horizontal: false, vertical: true)
 
                 if importedCount == 0 {
-                    Text("Make sure you're logged into YouTube in that profile, or pick another.")
+                    Text("Make sure you're logged into \(service.displayName) in that profile, or pick another.")
                         .font(HudFont.ui(HudTextSize.xs))
                         .foregroundStyle(pal.dim)
                         .fixedSize(horizontal: false, vertical: true)
@@ -335,15 +343,21 @@ struct CookieImportPanel: View {
         importedCount = 0
         phase = .working
         Task {
-            let count = await onImport(target.browser, target.profile, selectedAccountIndex)
+            let count = await onImport(target.browser, target.profile, service == .youTube ? selectedAccountIndex : 0)
             importedCount = count
-            // The reload + masthead read is async; give it a moment to confirm.
             if count > 0 {
-                for _ in 0..<24 where !account.signedIn {
-                    try? await Task.sleep(nanoseconds: 250_000_000)
+                if service == .youTube {
+                    // YouTube identity is read off the page masthead after reload.
+                    for _ in 0..<24 where !account.signedIn {
+                        try? await Task.sleep(nanoseconds: 250_000_000)
+                    }
+                    confirmed = account.signedIn
+                } else {
+                    confirmed = account.signedIn || count > 0
                 }
+            } else {
+                confirmed = false
             }
-            confirmed = account.signedIn
             phase = .done
         }
     }

--- a/apps/macos/Sources/PomoShared/Settings/SettingsView.swift
+++ b/apps/macos/Sources/PomoShared/Settings/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @Bindable var settings: PomoSettings
     @Bindable var favorites: FavoritesStore
     var account: AccountStatus
+    var soundCloudAccount: AccountStatus
     var onClose: () -> Void
     var onAudioPlay: (String) -> Void = { _ in }
     var onAudioPause: () -> Void = {}
@@ -17,6 +18,9 @@ struct SettingsView: View {
     var onSignIn: () -> Void = {}
     var onSignOut: () -> Void = {}
     var onImportLogin: () -> Void = {}
+    var onSoundCloudSignIn: () -> Void = {}
+    var onSoundCloudSignOut: () -> Void = {}
+    var onSoundCloudImportLogin: () -> Void = {}
 
     @Environment(\.colorScheme) private var scheme
     @State private var tab: SettingsTab = .general
@@ -222,7 +226,7 @@ struct SettingsView: View {
                     inputSurface(icon: "link") {
                         BrandTextField(
                             text: settings.binding(\.audioURL),
-                            placeholder: "Paste a YouTube link…",
+                            placeholder: "Paste a YouTube or SoundCloud link…",
                             textColor: pal.ink,
                             selectionColor: pal.action
                         )
@@ -367,6 +371,46 @@ struct SettingsView: View {
                 }
                 .padding(HudSpacing.lg)
             }
+
+            group("SOUNDCLOUD ACCOUNT") {
+                HStack(spacing: HudSpacing.md) {
+                    Image(systemName: soundCloudAccount.signedIn ? "person.crop.circle.fill" : "person.crop.circle")
+                        .font(.system(size: 28))
+                        .foregroundStyle(soundCloudAccount.signedIn ? pal.action : pal.dim)
+                        .frame(width: 32, height: 32)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(soundCloudAccount.signedIn ? (soundCloudAccount.name ?? "Signed in") : "Not signed in")
+                            .font(HudFont.ui(HudTextSize.sm, weight: .medium))
+                            .foregroundStyle(pal.ink)
+                        Text(soundCloudAccount.signedIn ? "Playlists and library unlocked" : "Import or sign in to skip login prompts")
+                            .font(HudFont.ui(HudTextSize.xs))
+                            .foregroundStyle(pal.dim)
+                    }
+                    Spacer()
+                    if soundCloudAccount.signedIn {
+                        button("Sign out") { onSoundCloudSignOut() }
+                    } else {
+                        button("Sign in", icon: "person.crop.circle", kind: .primary) { onSoundCloudSignIn() }
+                    }
+                }
+                .padding(HudSpacing.lg)
+
+                rowDivider
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Import login from browser")
+                            .font(HudFont.ui(HudTextSize.sm))
+                            .foregroundStyle(pal.ink)
+                        Text("Reuse a SoundCloud session you're already signed into.")
+                            .font(HudFont.ui(HudTextSize.xs))
+                            .foregroundStyle(pal.dim)
+                    }
+                    Spacer()
+                    button("Import…") { onSoundCloudImportLogin() }
+                }
+                .padding(HudSpacing.lg)
+            }
         }
     }
 
@@ -489,7 +533,7 @@ struct SettingsView: View {
                 Text("No saved videos")
                     .font(HudFont.ui(HudTextSize.sm, weight: .medium))
                     .foregroundStyle(pal.ink)
-                Text("Add YouTube links here to populate the menu player.")
+                Text("Add YouTube or SoundCloud links here to populate the menu player.")
                     .font(HudFont.ui(HudTextSize.xs))
                     .foregroundStyle(pal.dim)
             }
@@ -517,7 +561,7 @@ struct SettingsView: View {
             inputSurface(icon: "link", height: 30) {
                 BrandTextField(
                     text: $newFavoriteURL,
-                    placeholder: "Paste a YouTube link to save…",
+                    placeholder: "Paste a YouTube or SoundCloud link to save…",
                     textColor: pal.ink,
                     selectionColor: pal.action
                 )

--- a/apps/macos/docs/lattices-managed-browser-playback.md
+++ b/apps/macos/docs/lattices-managed-browser-playback.md
@@ -1,0 +1,484 @@
+# Lattices Managed Browser Playback
+
+Draft spec for using Lattices to control a real browser window for Pomo Amp
+playback, without CDP, cookie import, or Google sign-in inside `WKWebView`.
+
+Reviewed with the Lattices project through Scout: `ref:c-wu85gy`.
+
+## Goal
+
+Pomo Amp should offer a managed real-browser playback mode for users who want
+their normal YouTube session, including Premium, playlists, queue, and browser
+state. The browser remains a normal user browser window. Pomo Amp supplies the
+small transport HUD and visual attachment; Lattices supplies desktop/window/UI
+control.
+
+This is not an ad blocker or ad-bypass system. Ad-free playback comes from the
+user's own Premium session in their real browser.
+
+## Product Shape
+
+- Embedded WebKit remains the lightweight default player.
+- Managed browser playback is an explicit source named `Browser`, not `Chrome`.
+- The first implementation can target Google Chrome because that is the user's
+  current logged-in Premium surface.
+- The long-term contract should be browser-agnostic: `bundleId`, `appName`, and
+  URL/window targeting should let Safari or another browser work later.
+- Pomo Amp owns playback intent, menu bar UI, now-playing display, and whether
+  the browser drawer is shown or hidden.
+- Lattices owns locating, launching, moving, focusing, observing, and clicking
+  real macOS windows.
+
+## Non-Goals
+
+- No embedded Google OAuth.
+- No cookie copying as the main auth path.
+- No CDP or remote debugging profile.
+- No direct DOM scripting of YouTube.
+- No hidden ad skipping or behavior whose purpose is to bypass ads.
+- No global media-key control that could hit the wrong YouTube/browser window.
+
+## Existing Lattices APIs We Can Use
+
+### Health and Schema
+
+- `daemon.status`: check that the local daemon is running.
+- `api.schema`: discover current method shapes at runtime.
+
+### Window Discovery
+
+- `windows.list`: enumerate visible windows with `wid`, `app`, `pid`, `title`,
+  `frame`, `spaceIds`, and `isOnScreen`.
+- `windows.get`: refresh a tracked window by `wid`.
+- `windows.search` or `lattices.search`: find a browser window by app/title/OCR.
+- `windows.changed` event subscription: update Pomo if the browser window moves,
+  closes, changes title, or is replaced. Today this event is useful as an
+  invalidation signal, but it does not include detailed frame/title diffs.
+
+Current window records do not include `bundleId`, so Pomo should treat `wid`,
+`pid`, `app`, `title`, and user adoption as the initial identity anchors.
+
+### Window Placement and Focus
+
+- `computer.launchApp`: launch/focus a browser app by app name, bundle id, or
+  explicit app path.
+- `computer.focusWindow`: present or execute focus for a resolved window.
+- `actions.execute` with `type=window.place`: preferred canonical placement
+  surface when it can target a non-terminal window by `wid`.
+- `window.place` / `window.focus`: compatibility surfaces where needed.
+- `actions.undo`: useful for debug/recovery if a placement move goes wrong.
+
+Reviewed status: `actions.execute(window.place)` already accepts
+`target: { kind: "wid", wid }` and works for non-terminal windows, but current
+placement shapes are tile/grid/fractions. Exact global frames and
+`activation: none` need Lattices extensions.
+
+### Observation
+
+- `capture.screenshotWindow`: capture the browser window into a Lattices run.
+- `ocr.scan`, `ocr.snapshot`, `ocr.search`: fallback text observation when AX
+  names are insufficient.
+- `runs.create`, `runs.get`, `runs.artifacts`: attach traces/screenshots to each
+  browser-control attempt for debugging.
+
+### UI Actions
+
+- `computer.click`: click a window-relative target using `transport=auto`, `ax`,
+  or `pointer`; supports `axLabel`, `noFocus`, `xRatio`, and `yRatio`.
+- `computer.typeWindowText`: probably not needed for normal playback, but useful
+  for search/login recovery flows if the user explicitly chooses them.
+- `computer.magicCursor` / `computer.showCursor`: optional visible affordance for
+  staged/debug mode.
+
+## Lattices API Gaps / Requests
+
+The existing API is close for window management and simple clicking. For Pomo Amp
+to use this as a product-quality playback engine, we need a few stable contracts.
+
+### 1. Generic URL Open and Window Resolve
+
+The first draft proposed `browser.window.ensure`; Lattices review pushed back on
+that shape as too browser/YouTube-specific. Keep YouTube URL normalization,
+video id matching, and transport recipes in Pomo. If Lattices adds an API here,
+it should be generic.
+
+Needed API option A:
+
+```json
+{
+  "method": "url.open",
+  "params": {
+    "appName": "Google Chrome",
+    "bundleId": "com.google.Chrome",
+    "url": "https://www.youtube.com/watch?v=...",
+    "reusePolicy": "prefer-existing-window",
+    "source": "pomo-amp"
+  }
+}
+```
+
+Needed API option B:
+
+```json
+{
+  "method": "window.resolve",
+  "params": {
+    "target": {
+      "kind": "app",
+      "app": "Google Chrome",
+      "titleContains": "YouTube"
+    },
+    "source": "pomo-amp"
+  }
+}
+```
+
+Why Pomo needs it:
+
+- `computer.launchApp` can launch an app, but it does not define URL opening or
+  reuse behavior.
+- Pomo should not spawn a new browser window on every Show.
+- Pomo needs to know whether the tracked window is still the same logical player.
+
+Milestone 1 should avoid this problem entirely by adopting a user-selected
+front browser window instead of opening URLs automatically.
+
+### 2. Stable Non-Terminal Window Placement
+
+Needed API:
+
+```json
+{
+  "method": "actions.execute",
+  "params": {
+    "type": "window.place",
+    "target": { "kind": "wid", "wid": 12345 },
+    "args": {
+      "placement": {
+        "kind": "frame",
+        "x": 1200,
+        "y": 180,
+        "w": 520,
+        "h": 340,
+        "coordinateSpace": "global"
+      },
+      "activation": "none"
+    },
+    "source": "pomo-amp"
+  }
+}
+```
+
+Requirements:
+
+- Must work for Chrome/Safari, not only terminal sessions.
+- Must return the applied frame, previous frame, display/space, and `undoable`.
+- Must support `activation: none | present | focus`.
+- Must be safe when the target is on another Space: either switch Space
+  explicitly or return a recoverable error.
+
+Reviewed status: `target.kind = "wid"` works today, but exact `frame` placement
+and non-activating placement do not.
+
+### 3. Park / Restore Without Minimize
+
+Needed API:
+
+```json
+{
+  "method": "window.park",
+  "params": {
+    "wid": 12345,
+    "mode": "park|restore",
+    "parkingFrame": { "x": 4000, "y": 200, "w": 520, "h": 340 },
+    "source": "pomo-amp"
+  }
+}
+```
+
+Why:
+
+- Minimize feels wrong and can break the mental model.
+- Pomo wants Hide Video to tuck the browser away while preserving playback and
+  the window identity.
+- A parking-frame approach is acceptable if Lattices can make it reversible and
+  robust across display changes.
+
+Fallback:
+
+- Pomo can call `window.place` to park/restore if Lattices confirms that
+  offscreen frames are supported and safe.
+
+Reviewed status: Lattices should not promise true hidden/order-out playback for
+another app's browser window. Park/restore placement is the right model.
+
+### 4. Keyboard / Shortcut Action
+
+Needed API:
+
+```json
+{
+  "method": "keyboard.send",
+  "params": {
+    "wid": 12345,
+    "key": "space",
+    "modifiers": [],
+    "focusPolicy": "focus-required",
+    "treatment": "execute",
+    "source": "pomo-amp"
+  }
+}
+```
+
+Why:
+
+- YouTube transport sometimes has better keyboard shortcuts than clickable AX
+  controls.
+- Pomo needs scoped keys so Space/Left/Right/Shift+N do not hit the wrong
+  browser window.
+
+Candidate mappings:
+
+- Play/pause: `space` or click AX label `Play`/`Pause`.
+- Next: click AX label `Next`, fallback `Shift+N` for playlist contexts.
+- Previous: click AX label `Previous`, fallback `Shift+P` or visible button.
+- Seek: `ArrowLeft` / `ArrowRight` only if the browser window is correctly
+  targeted.
+
+Reviewed status: a no-focus, window-scoped keyboard guarantee is not realistic
+with normal macOS event delivery. Any keyboard fallback must focus and verify the
+target window first. Milestone 1 should avoid keyboard fallback.
+
+### 5. Accessibility Snapshot / Element Resolve
+
+Needed API:
+
+```json
+{
+  "method": "computer.inspectWindow",
+  "params": {
+    "wid": 12345,
+    "includeScreenshot": true,
+    "includeAX": true,
+    "includeOCR": true,
+    "source": "pomo-amp"
+  }
+}
+```
+
+Expected result:
+
+```json
+{
+  "wid": 12345,
+  "screenshotArtifact": "runs/.../window.png",
+  "ax": [
+    { "role": "button", "label": "Pause", "frame": { "...": "..." } }
+  ],
+  "ocr": [
+    { "text": "Pause", "confidence": 0.93, "frame": { "...": "..." } }
+  ]
+}
+```
+
+Needed companion:
+
+```json
+{
+  "method": "computer.resolveActionTarget",
+  "params": {
+    "wid": 12345,
+    "role": "button",
+    "labels": ["Pause", "Play"],
+    "fallback": ["ocr", "ratio"],
+    "source": "pomo-amp"
+  }
+}
+```
+
+Why:
+
+- `computer.click` has `axLabel`, which is good for execution, but Pomo needs a
+  way to preflight and explain what it thinks it will press.
+- This lets the UI show "Browser controls ready" versus "Need user help".
+
+Reviewed status: avoid stable AX ids; AX elements are ephemeral. A good first
+step may be enhancing `computer.click` stage mode to return the chosen AX
+candidate without pressing.
+
+### 6. Permission Status
+
+Needed API:
+
+```json
+{
+  "method": "permissions.status",
+  "params": {
+    "capabilities": ["windowControl", "screenSearch", "voiceCapture"],
+    "source": "pomo-amp"
+  }
+}
+```
+
+Needed companion:
+
+```json
+{
+  "method": "permissions.openSettings",
+  "params": { "capability": "accessibility", "source": "pomo-amp" }
+}
+```
+
+Why:
+
+- Pomo needs to render setup state before a user presses Browser mode.
+- We should not ask blind or retry in a loop.
+- If Lattices already owns permission education, Pomo should deep-link there
+  rather than duplicate it.
+
+Reviewed status: Lattices currently models `windowControl` as Accessibility,
+`screenSearch` as Screen Recording, and `voiceCapture` as Microphone. It does
+not currently model Input Monitoring through this capability layer.
+
+### 7. Receipts and Run Traces
+
+Every mutating browser-control call should eventually return:
+
+- `requestId`
+- `runId`
+- target `wid` and app identity
+- attempted transport (`ax`, `pointer`, `keyboard`, placement)
+- before/after frame or screenshot artifact where relevant
+- `ok`, `verification`, and a human-readable trace
+
+This matters because failures will otherwise feel spooky: "play/pause just
+switched windows" is exactly the class of bug receipts should explain.
+
+Reviewed status: this is aspirational across surfaces today. Placement returns
+action receipts; computer/capture calls return run objects and artifacts. Pomo
+should tolerate that split.
+
+## Pomo App Framework
+
+### New Components
+
+`LatticesClient`
+
+- Swift JSON-RPC-over-WebSocket client to `ws://127.0.0.1:9399`.
+- Calls `daemon.status` and `api.schema` on startup.
+- Exposes typed async wrappers for the subset above.
+- Does not shell out to `lattices` or depend on Node/Bun.
+
+`ManagedBrowserPlaybackController`
+
+- Owns the Lattices-backed playback state machine.
+- Tracks `wid`, browser identity, current URL/video id, last visible frame,
+  parked frame, and readiness.
+- Converts Pomo actions into Lattices calls.
+
+`BrowserPlaybackRecipe`
+
+- Encodes browser-specific defaults for YouTube:
+  - URL normalization
+  - title/video matching
+  - play/pause/next/previous action candidates
+  - fallback coordinate ratios for the YouTube player chrome
+
+`AudioController` integration
+
+- Keep WebKit as default.
+- Add explicit source only after this is proven: `.webkit` and `.browser`.
+- Do not reintroduce CDP or cookie import as hidden source behavior.
+
+### State Machine
+
+- `unavailable`: Lattices daemon not reachable.
+- `needsPermission`: Lattices is reachable but lacks required permissions.
+- `idle`: no browser window tracked.
+- `opening`: launching/finding/navigating browser.
+- `ready`: tracked browser window is known and controls are resolvable.
+- `visible`: tracked browser window is placed next to Pomo Amp.
+- `hidden`: tracked browser window is parked/restorable.
+- `recovering`: wid disappeared or control verification failed.
+- `failed`: action failed with receipt; user can retry or open browser manually.
+
+### Action Flow
+
+Open/play URL:
+
+1. Pomo normalizes URL and extracts YouTube video id.
+2. Milestone 1: adopt an existing user-selected browser window.
+3. Future: generic `url.open` or app open URL, then resolve/adopt the window.
+4. Place window next to Amp HUD using Lattices placement.
+5. Observe/snapshot controls.
+6. Click Play or send scoped key only if the target is verified.
+7. Store `wid`, frame, source URL, and receipt.
+
+Play/pause:
+
+1. If `ready`, prefer AX button label `Pause`/`Play` with `noFocus`.
+2. If AX fails, resolve element from snapshot.
+3. Milestone 1: if AX click is ambiguous, fail with a receipt and ask for
+   user help.
+4. Future: focus target and send scoped `space` only when `wid` is still the
+   tracked browser window.
+5. Save receipt and update Pomo state optimistically only after success.
+
+Show/hide:
+
+1. Show restores last visible frame and optionally activates Pomo Amp after.
+2. Hide parks/restores without minimizing and without closing the browser.
+3. If the user manually closes the browser window, Pomo transitions to `idle`.
+
+Next/previous:
+
+1. Prefer AX button labels.
+2. Future: fall back to focused, verified keyboard shortcut.
+3. Never send global media keys.
+
+## UX
+
+- Menubar source should say `Browser` only when enabled, never `Chrome`.
+- Setup copy: "Use your real browser session for Premium playback."
+- If Lattices is unavailable: "Browser control needs Lattices running."
+- If permissions are missing: show a single setup action, not repeated prompts.
+- Debug view can show the latest Lattices receipt/run id.
+
+## Open Questions for Lattices
+
+1. Should Pomo use existing `actions.execute/window.place` directly, with an
+   extension for exact frames and activation policy?
+2. Does `window.place` already support arbitrary `wid` targets and exact frames
+   for non-terminal windows?
+3. Should Lattices add generic `url.open`, or should Pomo launch URLs itself and
+   only use Lattices for adoption/control?
+4. What is the preferred no-minimize hide strategy: parking frame, Space move,
+   ordered-out equivalent, or something else?
+5. Is a focus-required keyboard action already available but undocumented?
+6. Can `computer.click` return enough preflight detail for Pomo, or should we add
+   `computer.inspectWindow` / `computer.resolveActionTarget`?
+7. How should Pomo surface Lattices permission status without duplicating the
+   Lattices settings UI?
+8. Should the browser-control recipe live in Pomo, in Lattices, or as shared
+   declarative data?
+
+## First Milestone Proposal
+
+Build a thin spike behind a debug flag:
+
+- Add `LatticesClient` with `daemon.status`, `windows.list`, `computer.click`,
+  `capture.screenshotWindow`, and `actions.execute`.
+- Add a manual "Adopt Front Browser Window" debug action.
+- Support only show/place with fractions placement and play/pause click by AX
+  label.
+- No automatic browser launching yet.
+- No offscreen hide/park yet.
+- No keyboard fallback yet.
+- Use Lattices run receipts for every action.
+
+Success criteria:
+
+- No extra browser windows after repeated show/hide.
+- Play/pause targets the adopted YouTube window, not another YouTube tab/window.
+- Hide/show does not minimize and does not reload.
+- Failures produce a receipt with target, transport, and reason.

--- a/apps/macos/tools/cookie-helper/src/main.rs
+++ b/apps/macos/tools/cookie-helper/src/main.rs
@@ -1,26 +1,43 @@
 // pomo-cookies — tiny cross-browser cookie extractor for Pomo.
 //
-// Prints YouTube/Google cookies (Netscape cookies.txt format) using the `rookie`
-// crate, so a signed-in YouTube session can be borrowed without a fresh login.
+// Prints auth cookies (Netscape cookies.txt format) using the `rookie` crate, so
+// a signed-in web-player session can be borrowed without a fresh login.
 //
 // Usage:
-//   pomo-cookies                      try all detected browsers
-//   pomo-cookies <browser>            default profile of that browser
-//   pomo-cookies <browser> <profile>  a specific Chromium profile, e.g.
-//                                      `pomo-cookies chrome "Profile 1"`
+//   pomo-cookies [--soundcloud]              try all detected browsers
+//   pomo-cookies [--soundcloud] <browser>    default profile of that browser
+//   pomo-cookies [--soundcloud] <browser> <profile>
+//                                      e.g. `pomo-cookies chrome "Profile 1"`
+//                                      or   `pomo-cookies --soundcloud chrome`
 use std::env;
 use std::path::Path;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let browser = args.get(1).map(|s| s.to_lowercase());
-    let profile = args.get(2).cloned();
+    let mut soundcloud = false;
+    let mut positional: Vec<String> = Vec::new();
+    for arg in args.iter().skip(1) {
+        if arg == "--soundcloud" {
+            soundcloud = true;
+        } else {
+            positional.push(arg.clone());
+        }
+    }
 
-    // YouTube auth cookies live on both youtube.com and google.com.
-    let domains = Some(vec!["youtube.com".to_string(), "google.com".to_string()]);
+    let browser = positional.first().map(|s| s.to_lowercase());
+    let profile = positional.get(1).cloned();
+
+    let domains = if soundcloud {
+        Some(vec!["soundcloud.com".to_string()])
+    } else {
+        Some(vec!["youtube.com".to_string(), "google.com".to_string()])
+    };
 
     let result = match (browser.as_deref(), profile.as_deref()) {
-        // Specific Chromium profile → point rookie at that profile's cookie DB.
+        (Some(b), Some(_)) | (Some(b), None) if b.starts_with('-') => {
+            eprintln!("pomo-cookies: unknown option '{b}' — rebuild the app to pick up cookie-helper updates");
+            std::process::exit(2);
+        }
         (Some(b), Some(profile_dir)) => match chromium_cookie_db(b, profile_dir) {
             Some(db) => rookie::any_browser(&db, domains, None),
             None => {


### PR DESCRIPTION
SoundCloud URLs now play through the web player with embed/canonical resolution, and users can sign in or import browser cookies independently from YouTube so one login does not overwrite the other.