### PR TITLE
Cover Photo face images in Pomo privacy policy

### DIFF
--- a/landing/app/privacy/page.tsx
+++ b/landing/app/privacy/page.tsx
@@ -3,13 +3,13 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Privacy Policy — Pomo",
-  description: "How Pomo handles timer settings, session history, and website analytics.",
+  description: "How Pomo handles timer settings, session history, Photo face images, and website analytics.",
 };
 
 const sections = [
   {
     title: "The Pomo app",
-    body: "Pomo does not require an account and does not include advertising or analytics SDKs. Timer settings, session intentions, and activity history are stored locally on your device. The app does not send that information to us or to third parties.",
+    body: "Pomo does not require an account and does not include advertising or analytics SDKs. Timer settings, session intentions, activity history, and any image you choose for the Photo face are stored locally on your device. The app does not send that information to us or to third parties.",
   },
   {
     title: "Notifications",


### PR DESCRIPTION
## What changed

- states that Photo face images stay locally on the device
- updates the privacy-page metadata to include Photo face images

## Why

The public privacy policy now matches the personal Photo face behavior in the App Store build.

## Validation

- `bun run build` passes
- App Store Connect already points to `https://pomo.arach.dev/privacy`